### PR TITLE
8309595: Allow javadoc to process unnamed classes

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
@@ -987,7 +987,7 @@ public class ElementsTable {
      * @return true if the element is visible
      */
     public boolean isSelected(Element e) {
-        if (toolEnv.isSynthetic((Symbol) e)) {
+        if (toolEnv.isSynthetic((Symbol) e) && !toolEnv.isUnnamed((Symbol) e)) {
             return false;
         }
         if (visibleElementVisitor == null) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ToolEnvironment.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ToolEnvironment.java
@@ -174,6 +174,10 @@ public class ToolEnvironment {
         return (sym.flags() & Flags.SYNTHETIC) != 0;
     }
 
+    boolean isUnnamed(Symbol sym) {
+        return (sym.flags() & Flags.UNNAMED_CLASS) != 0;
+    }
+
     void setElementToTreePath(Element e, TreePath tree) {
         if (e == null || tree == null)
             return;

--- a/test/langtools/jdk/javadoc/doclet/unnamed/Unnamed.java
+++ b/test/langtools/jdk/javadoc/doclet/unnamed/Unnamed.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8309595
+ * @summary Allow javadoc to process unnamed classes
+ * @library  /tools/lib ../../lib
+ * @modules  jdk.javadoc/jdk.javadoc.internal.tool
+ * @build    toolbox.ToolBox javadoc.tester.*
+ * @run main Unnamed
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+public class Unnamed extends JavadocTester {
+
+    private static final String thisVersion = System.getProperty("java.specification.version");
+
+    private static final ToolBox tb = new ToolBox();
+
+    public static void main(String... args) throws Exception {
+        new Unnamed().runTests();
+    }
+
+    @Test
+    public void testUnnamed(Path base) throws IOException {
+        String className = "Sample";
+        Files.createDirectories(base);
+        Path out = base.resolve("out");
+        Path src = base.resolve("src");
+        Path sample = src.resolve(className + ".java");
+
+        Files.createDirectories(out);
+        Files.createDirectories(src);
+        Files.writeString(sample, """
+            /**
+             * This is a comment for the main method.
+             */
+            void main() {
+                System.out.println("Done");
+            }
+            """);
+
+         javadoc(
+             "--enable-preview",
+             "--source", thisVersion,
+             "-private",
+             "-d", out.toString(),
+             sample.toString()
+         );
+
+        checkOutput(className + ".html", true, "This is a comment for the main method.");
+    }
+
+}


### PR DESCRIPTION
Unnamed classes are rejected by javadoc because they are synthetic.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309595](https://bugs.openjdk.org/browse/JDK-8309595): Allow javadoc to process unnamed classes (**Bug** - P3)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/1/head:pull/1` \
`$ git checkout pull/1`

Update a local copy of the PR: \
`$ git checkout pull/1` \
`$ git pull https://git.openjdk.org/jdk21.git pull/1/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1`

View PR using the GUI difftool: \
`$ git pr show -t 1`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/1.diff">https://git.openjdk.org/jdk21/pull/1.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/1#issuecomment-1583111015)