### PR TITLE
8309675: Generational ZGC: compiler/gcbarriers/UnsafeIntrinsicsTest.java fails in nmt_commit

### DIFF
--- a/src/hotspot/share/gc/z/zPhysicalMemory.cpp
+++ b/src/hotspot/share/gc/z/zPhysicalMemory.cpp
@@ -283,15 +283,15 @@ void ZPhysicalMemoryManager::nmt_commit(zoffset offset, size_t size) const {
   // When this function is called we don't know where in the virtual memory
   // this physical memory will be mapped. So we fake that the virtual memory
   // address is the heap base + the given offset.
-  const zaddress addr = ZOffset::address(offset);
-  MemTracker::record_virtual_memory_commit((void*)untype(addr), size, CALLER_PC);
+  const uintptr_t addr = ZAddressHeapBase + untype(offset);
+  MemTracker::record_virtual_memory_commit((void*)addr, size, CALLER_PC);
 }
 
 void ZPhysicalMemoryManager::nmt_uncommit(zoffset offset, size_t size) const {
   if (MemTracker::enabled()) {
-    const zaddress addr = ZOffset::address(offset);
+    const uintptr_t addr = ZAddressHeapBase + untype(offset);
     Tracker tracker(Tracker::uncommit);
-    tracker.record((address)untype(addr), size);
+    tracker.record((address)addr, size);
   }
 }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309675](https://bugs.openjdk.org/browse/JDK-8309675): Generational ZGC: compiler/gcbarriers/UnsafeIntrinsicsTest.java fails in nmt_commit (**Bug** - P2)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/2/head:pull/2` \
`$ git checkout pull/2`

Update a local copy of the PR: \
`$ git checkout pull/2` \
`$ git pull https://git.openjdk.org/jdk21.git pull/2/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2`

View PR using the GUI difftool: \
`$ git pr show -t 2`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/2.diff">https://git.openjdk.org/jdk21/pull/2.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/2#issuecomment-1583262160)