### PR TITLE
8309727: Assert privileges while reading the jdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK system property

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorIntrinsics.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorIntrinsics.java
@@ -26,10 +26,14 @@ package jdk.incubator.vector;
 
 import jdk.internal.vm.annotation.ForceInline;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Objects;
 
 /*non-public*/ class VectorIntrinsics {
-    static final int VECTOR_ACCESS_OOB_CHECK = Integer.getInteger("jdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK", 2);
+    @SuppressWarnings("removal")
+    static final int VECTOR_ACCESS_OOB_CHECK = AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
+            Integer.getInteger("jdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK", 2));
 
     @ForceInline
     static void requireLength(int haveLength, int length) {

--- a/test/jdk/jdk/incubator/vector/VectorRuns.java
+++ b/test/jdk/jdk/incubator/vector/VectorRuns.java
@@ -27,7 +27,10 @@ import java.util.stream.IntStream;
 
 /**
  * @test
+ * @bug 8309727
  * @modules jdk.incubator.vector
+ * @run main VectorRuns
+ * @run main/othervm/java.security.policy=empty_security.policy VectorRuns
  */
 
 public class VectorRuns {
@@ -68,7 +71,7 @@ public class VectorRuns {
         if (r >= a.length)
             return a.length;
 
-        int length = a.length & (species.length() - 1);
+        int length = species.loopBound(a.length);
         if (length == a.length) length -= species.length();
         while (r < length) {
             IntVector vl = IntVector.fromArray(species, a, r - 1);

--- a/test/jdk/jdk/incubator/vector/empty_security.policy
+++ b/test/jdk/jdk/incubator/vector/empty_security.policy
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+//
+// This code is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License version 2 only, as
+// published by the Free Software Foundation.
+//
+// This code is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// version 2 for more details (a copy is included in the LICENSE file that
+// accompanied this code).
+//
+// You should have received a copy of the GNU General Public License version
+// 2 along with this work; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+// or visit www.oracle.com if you need additional information or have any
+// questions.
+//
+
+// This policy is used by tests not requiring permissions, to assert that the
+// JDK implementation has the correct privileged blocks.


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [cee5724d](https://github.com/openjdk/jdk/commit/cee5724d09b9ef9bd528fb721b756cb052265e3d) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Chris Hegarty on 9 Jun 2023 and was reviewed by Roger Riggs, Uwe Schindler and Paul Sandoz.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309727](https://bugs.openjdk.org/browse/JDK-8309727): Assert privileges while reading the jdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK system property (**Bug** - P3)


### Reviewers
 * [Uwe Schindler](https://openjdk.org/census#uschindler) (@uschindler - Author)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/3/head:pull/3` \
`$ git checkout pull/3`

Update a local copy of the PR: \
`$ git checkout pull/3` \
`$ git pull https://git.openjdk.org/jdk21.git pull/3/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3`

View PR using the GUI difftool: \
`$ git pr show -t 3`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/3.diff">https://git.openjdk.org/jdk21/pull/3.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/3#issuecomment-1585061344)