### PR TITLE
8309882: LinkedHashMap adds an errant serializable field

### DIFF
--- a/src/java.base/share/classes/java/util/LinkedHashMap.java
+++ b/src/java.base/share/classes/java/util/LinkedHashMap.java
@@ -330,7 +330,7 @@ public class LinkedHashMap<K,V>
     static final int PUT_NORM = 0;
     static final int PUT_FIRST = 1;
     static final int PUT_LAST = 2;
-    int putMode = PUT_NORM;
+    transient int putMode = PUT_NORM;
 
     // Called after update, but not after insertion
     void afterNodeAccess(Node<K,V> e) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e1386856](https://github.com/openjdk/jdk/commit/e138685648fb7a756a05f314af2883ce408abdd2) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Stuart Marks on 13 Jun 2023 and was reviewed by Joe Darcy, Brian Burkhalter, Jaikiran Pai and Roger Riggs.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8309885](https://bugs.openjdk.org/browse/JDK-8309885) to be approved

### Issues
 * [JDK-8309882](https://bugs.openjdk.org/browse/JDK-8309882): LinkedHashMap adds an errant serializable field (**Bug** - P3)
 * [JDK-8309885](https://bugs.openjdk.org/browse/JDK-8309885): LinkedHashMap adds an errant serializable field (**CSR**)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.org/jdk21.git pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/15.diff">https://git.openjdk.org/jdk21/pull/15.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/15#issuecomment-1589977810)