### PR TITLE
8309613: [Windows] hs_err files sometimes miss information about the code containing the error

### DIFF
--- a/src/hotspot/os/aix/os_aix.hpp
+++ b/src/hotspot/os/aix/os_aix.hpp
@@ -172,7 +172,7 @@ class os::Aix {
   // Returns true if ok, false if error.
   static bool get_meminfo(meminfo_t* pmi);
 
-  static bool platform_print_native_stack(outputStream* st, const void* context, char *buf, int buf_size);
+  static bool platform_print_native_stack(outputStream* st, const void* context, char *buf, int buf_size, address& lastpc);
   static void* resolve_function_descriptor(void* p);
 };
 

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -48,7 +48,7 @@ class os::win32 {
   static void print_uptime_info(outputStream* st);
 
   static bool platform_print_native_stack(outputStream* st, const void* context,
-                                          char *buf, int buf_size);
+                                          char *buf, int buf_size, address& lastpc);
 
   static bool register_code_area(char *low, char *high);
 

--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -516,7 +516,7 @@ int os::extra_bang_size_in_bytes() {
   return 0;
 }
 
-bool os::Aix::platform_print_native_stack(outputStream* st, const void* context, char *buf, int buf_size) {
+bool os::Aix::platform_print_native_stack(outputStream* st, const void* context, char *buf, int buf_size, address& lastpc) {
   AixNativeCallstack::print_callstack_for_context(st, (const ucontext_t*)context, true, buf, (size_t) buf_size);
   return true;
 }

--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.inline.hpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.inline.hpp
@@ -30,8 +30,8 @@
 
 #define HAVE_PLATFORM_PRINT_NATIVE_STACK 1
 inline bool os::platform_print_native_stack(outputStream* st, const void* context,
-                                            char *buf, int buf_size) {
-  return os::Aix::platform_print_native_stack(st, context, buf, buf_size);
+                                            char *buf, int buf_size, address& lastpc) {
+  return os::Aix::platform_print_native_stack(st, context, buf, buf_size, lastpc);
 }
 
 #define HAVE_FUNCTION_DESCRIPTORS 1

--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.inline.hpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.inline.hpp
@@ -31,8 +31,8 @@
 #ifdef AMD64
 #define HAVE_PLATFORM_PRINT_NATIVE_STACK 1
 inline bool os::platform_print_native_stack(outputStream* st, const void* context,
-                                     char *buf, int buf_size) {
-  return os::win32::platform_print_native_stack(st, context, buf, buf_size);
+                                     char *buf, int buf_size, address& lastpc) {
+  return os::win32::platform_print_native_stack(st, context, buf, buf_size, lastpc);
 }
 #endif
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -1008,7 +1008,7 @@ class os: AllStatic {
 
  public:
   inline static bool platform_print_native_stack(outputStream* st, const void* context,
-                                                 char *buf, int buf_size);
+                                                 char *buf, int buf_size, address& lastpc);
 
   // debugging support (mostly used by debug.cpp but also fatal error handler)
   static bool find(address pc, outputStream* st = tty); // OS specific function to make sense out of an address

--- a/src/hotspot/share/runtime/os.inline.hpp
+++ b/src/hotspot/share/runtime/os.inline.hpp
@@ -35,7 +35,7 @@
 
 #ifndef HAVE_PLATFORM_PRINT_NATIVE_STACK
 inline bool os::platform_print_native_stack(outputStream* st, const void* context,
-                                     char *buf, int buf_size) {
+                                     char *buf, int buf_size, address& lastpc) {
   return false;
 }
 #endif

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -654,7 +654,8 @@ extern "C" JNIEXPORT void pns(void* sp, void* fp, void* pc) { // print native st
 extern "C" JNIEXPORT void pns2() { // print native stack
   Command c("pns2");
   static char buf[O_BUFLEN];
-  if (os::platform_print_native_stack(tty, nullptr, buf, sizeof(buf))) {
+  address lastpc = nullptr;
+  if (os::platform_print_native_stack(tty, nullptr, buf, sizeof(buf), lastpc)) {
     // We have printed the native stack in platform-specific code,
     // so nothing else to do in this case.
   } else {


### PR DESCRIPTION
We need good hs_err files in JDK21 in case a problem like https://bugs.openjdk.org/secure/attachment/103766/hs_err_pid7652.log occurs again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309613](https://bugs.openjdk.org/browse/JDK-8309613): [Windows] hs_err files sometimes miss information about the code containing the error (**Bug** - P3)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/17/head:pull/17` \
`$ git checkout pull/17`

Update a local copy of the PR: \
`$ git checkout pull/17` \
`$ git pull https://git.openjdk.org/jdk21.git pull/17/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17`

View PR using the GUI difftool: \
`$ git pr show -t 17`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/17.diff">https://git.openjdk.org/jdk21/pull/17.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/17#issuecomment-1590747404)