### PR TITLE
8309956: Shenandoah: Strengthen the mark word check in string dedup

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahStringDedup.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahStringDedup.inline.hpp
@@ -45,14 +45,15 @@ bool ShenandoahStringDedup::is_candidate(oop obj) {
     return false;
   }
 
-  if (StringDedup::is_below_threshold_age(obj->age())) {
-    const markWord mark = obj->mark();
-    // Having/had displaced header, too risk to deal with them, skip
-    if (mark == markWord::INFLATING() || mark.has_displaced_mark_helper()) {
-      return false;
-    }
+  const markWord mark = obj->mark();
 
-    // Increase string age and enqueue it when it rearches age threshold
+  // Having/had displaced header, too risky to deal with them, skip
+  if (mark == markWord::INFLATING() || mark.has_displaced_mark_helper()) {
+    return false;
+  }
+
+  if (StringDedup::is_below_threshold_age(mark.age())) {
+    // Increase string age and enqueue it when it reaches age threshold
     markWord new_mark = mark.incr_age();
     if (mark == obj->cas_set_mark(new_mark, mark)) {
       return StringDedup::is_threshold_age(new_mark.age()) &&


### PR DESCRIPTION
Clean backport to improve Shenandoah reliability.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309956](https://bugs.openjdk.org/browse/JDK-8309956): Shenandoah: Strengthen the mark word check in string dedup (**Enhancement** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.org/jdk21.git pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/19.diff">https://git.openjdk.org/jdk21/pull/19.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/19#issuecomment-1591685949)