### PR TITLE
8310128: Switch with unnamed patterns erroneously non-exhaustive

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -3501,9 +3501,7 @@ public class Flow {
             }
             return new RecordPattern(record.type, componentTypes, nestedDescriptions);
         } else if (pattern instanceof JCAnyPattern) {
-            Type type = types.isSubtype(selectorType, syms.objectType)
-                    ? selectorType : syms.objectType;
-            return new BindingPattern(type);
+            return new BindingPattern(selectorType);
         } else {
             throw Assert.error();
         }

--- a/test/langtools/tools/javac/patterns/Unnamed.java
+++ b/test/langtools/tools/javac/patterns/Unnamed.java
@@ -79,6 +79,8 @@ public class Unnamed {
         assertEquals(2, testMixVarWithExplicit(new Box<>(new R2())));
         assertEquals("binding", unnamedGuardAddsBindings("match1", "binding"));
         assertEquals("any", unnamedGuardAddsBindings(42, 42));
+        assertEquals(true, testUnnamedPrimitiveAndExhaustiveness(new Prim1(4)));
+        assertEquals(false, testUnnamedPrimitiveAndExhaustiveness(new Prim2(5)));
 
         unnamedTest();
     }
@@ -269,6 +271,29 @@ public class Unnamed {
             case Object _: yield "any";
         };
     }
+
+    boolean testUnnamedPrimitiveAndExhaustiveness(RecordWithPrimitive a) {
+        boolean r1 = switch (a) {
+            case Prim1(var _) -> true;
+            case Prim2(_) -> false;
+        };
+
+        boolean r2 = switch (a) {
+            case Prim1(var _) -> true;
+            case Prim2(var _) -> false;
+        };
+
+        boolean r3 = switch (a) {
+            case Prim1(_) -> true;
+            case Prim2(_) -> false;
+        };
+
+        return r1 && r2 && r3;
+    }
+
+    sealed interface RecordWithPrimitive permits Prim1, Prim2 {};
+    record Prim1(int n1) implements RecordWithPrimitive {};
+    record Prim2(int n2) implements RecordWithPrimitive {};
 
     // JEP 443 examples
     record Point(int x, int y) { }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [32243ef4](https://github.com/openjdk/jdk/commit/32243ef47df75241302e243b4fd9627d686437fe) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Aggelos Biboudis on 16 Jun 2023 and was reviewed by Vicente Romero and Jan Lahoda.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310128](https://bugs.openjdk.org/browse/JDK-8310128): Switch with unnamed patterns erroneously non-exhaustive (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.org/jdk21.git pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/23.diff">https://git.openjdk.org/jdk21/pull/23.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/23#issuecomment-1594296463)