### PR TITLE
8303916: ThreadLists.java inconsistent results

### DIFF
--- a/test/jdk/java/lang/management/ThreadMXBean/ThreadLists.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/ThreadLists.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,10 +30,26 @@
  * @run main/othervm ThreadLists
  */
 import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 public class ThreadLists {
+
+    // Thread names permitted to appear during test:
+    public static final String [] permittedThreadNames = { "ForkJoinPool", "JVMCI" };
+
+    public static boolean isPermittedNewThread(String name) {
+        for (String s : permittedThreadNames) {
+            if (name.contains(s)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static void main(String args[]) {
 
         // Bug id : JDK-8151797
@@ -50,43 +66,80 @@ public class ThreadLists {
         } while (parent != null);
 
         // get the thread count
-        int activeCount = top.activeCount();
+        int tgActiveCount = top.activeCount();
 
         // Now enumerate to see if we find any extras yet.
-        // Ensure the array is big enough for a few extras.
-        Thread[] threads = new Thread[activeCount * 2];
-        int newCount = top.enumerate(threads);
-        if (newCount != activeCount) {
-            System.out.println("Found different threads after enumeration:");
-        } else {
-            System.out.println("Initial set of enumerated threads:");
-        }
-        for (int i = 0; i < newCount; i++) {
-            System.out.println(" - Thread: " + threads[i].getName());
-        }
-
+        // Ensure array is big enough for a few extras.
+        Thread[] tgThreads = new Thread[tgActiveCount * 2];
+        int tgNewCount = top.enumerate(tgThreads);
         Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();
 
-        ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
-        int threadCount = threadBean.getThreadCount();
-        long[] threadIds = threadBean.getAllThreadIds();
+        if (tgNewCount != tgActiveCount) {
+            System.out.println("Found different Thread Group thread count after enumeration: tgActiveCount="
+                               + tgActiveCount + " enumerated=" + tgNewCount);
+        }
+        if (tgNewCount != stackTraces.size()) {
+            System.out.println("Found difference in counts: thread group new count="
+                               + tgNewCount + " stackTraces.size()=" + stackTraces.size());
+        }
+        System.out.println("Initial set of enumerated threads:");
+        for (int i = 0; i < tgNewCount; i++) {
+            System.out.println(" - Thread: " + tgThreads[i].getName());
+        }
 
-        System.out.println("ThreadGroup: " + activeCount + " active thread(s)");
-        System.out.println("Thread: " + stackTraces.size() + " stack trace(s) returned");
-        System.out.println("ThreadMXBean: " + threadCount + " live threads(s)");
-        System.out.println("ThreadMXBean: " + threadIds.length + " thread Id(s)");
+        // Get Threads from MXBean.  Retry to ensure count and id count match.
+        ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+        int threadCountBean = 0;
+        long[] threadIdsBean = null;
+        do {
+            System.out.println("Gathering Thread info from MXBean...");
+            threadCountBean = threadBean.getThreadCount();
+            threadIdsBean = threadBean.getAllThreadIds();
+        } while (threadCountBean != threadIdsBean.length);
+
+        System.out.println("ThreadGroup:              " + tgActiveCount + " active thread(s)");
+        System.out.println("Thread.getAllStackTraces: " + stackTraces.size() + " stack trace(s) returned");
+        System.out.println("ThreadMXBean:             " + threadCountBean + " live threads(s)");
+        System.out.println("ThreadMXBean:             " + threadIdsBean.length + " thread Id(s)");
+
+        if (threadIdsBean.length > tgActiveCount) {
+            // Find the new Threads: some Thead names are permitted to appear: ignore them.
+            Set<Long> seenTids = new TreeSet<>();
+            for (Thread t : stackTraces.keySet()) {
+                if (t != null) {
+                    seenTids.add(t.getId());
+                }
+            }
+            for (long tid : threadIdsBean) {
+                if (!seenTids.contains(tid)) {
+                    // New Thread from MBean, compared to Thread Group:
+                    ThreadInfo threadInfo = threadBean.getThreadInfo(tid);
+                    if (threadInfo != null && isPermittedNewThread(threadInfo.getThreadName())) {
+                        System.out.print("New thread permitted: " + threadInfo);
+                        threadCountBean--;
+                    }
+                }
+            }
+        }
 
         // check results are consistent
         boolean failed = false;
-        if (activeCount != stackTraces.size()) failed = true;
-        if (activeCount != threadCount) failed = true;
-        if (activeCount != threadIds.length) failed = true;
+        if (tgActiveCount != stackTraces.size()) failed = true;
+        if (tgActiveCount != threadCountBean) failed = true;
+        // We know threadCountBean == threadIdsBean.length
 
         if (failed) {
-            System.out.println("Set of stack-traced threads:");
+            System.out.println("Failed.");
+            System.out.println("Set of Threads from getAllStackTraces:");
             for (Thread t : stackTraces.keySet()) {
                 System.out.println(" - Thread: " +
                                    (t != null ? t.getName() : "null!"));
+            }
+            System.out.println("Set of Thread IDs from MXBean:");
+            for (long tid : threadIdsBean) {
+                System.out.print(tid + " ");
+                ThreadInfo threadInfo = threadBean.getThreadInfo(tid);
+                System.out.println(threadInfo != null ? threadInfo.getThreadName() : "");
             }
             throw new RuntimeException("inconsistent results");
         }


### PR DESCRIPTION
Clean backport from latest jdk repo to jdk21 for the test change:
8303916: ThreadLists.java inconsistent results

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303916](https://bugs.openjdk.org/browse/JDK-8303916): ThreadLists.java inconsistent results (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.org/jdk21.git pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/24.diff">https://git.openjdk.org/jdk21/pull/24.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/24#issuecomment-1594387718)