### PR TITLE
8309756: Occasional crashes with pipewire screen capture on Wayland

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
@@ -89,8 +89,10 @@ static void doCleanup() {
         struct ScreenProps *screenProps = &screenSpace.screens[i];
         if (screenProps->data) {
             if (screenProps->data->stream) {
+                fp_pw_thread_loop_lock(pw.loop);
                 fp_pw_stream_disconnect(screenProps->data->stream);
                 fp_pw_stream_destroy(screenProps->data->stream);
+                fp_pw_thread_loop_unlock(pw.loop);
                 screenProps->data->stream = NULL;
             }
             free(screenProps->data);
@@ -892,8 +894,10 @@ JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_getRGBPixelsImpl
             screenProps->captureData = NULL;
             screenProps->shouldCapture = FALSE;
 
+            fp_pw_thread_loop_lock(pw.loop);
             fp_pw_stream_set_active(screenProps->data->stream, FALSE);
             fp_pw_stream_disconnect(screenProps->data->stream);
+            fp_pw_thread_loop_unlock(pw.loop);
         }
     }
     doCleanup();


### PR DESCRIPTION
I'd like to backport the fix for this crash to the JDK 21 stabilisation repo.
The fix is in code that is only used by AWT Robot on Wayland desktops so is quite isolated and unlikely to affect anything else.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309756](https://bugs.openjdk.org/browse/JDK-8309756): Occasional crashes with pipewire screen capture on Wayland (**Bug** - P3)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.org/jdk21.git pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/25.diff">https://git.openjdk.org/jdk21/pull/25.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/25#issuecomment-1595290935)