### PR TITLE
8309471: Limit key characters in static index pages

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexBuilder.java
@@ -300,7 +300,14 @@ public class IndexBuilder {
     }
 
     private static Character keyCharacter(String s) {
-        return s.isEmpty() ? '*' : Character.toUpperCase(s.charAt(0));
+        // Use first valid java identifier start character as key,
+        // or '*' for strings that do not contain one.
+        for (int i = 0; i < s.length(); i++) {
+            if (Character.isJavaIdentifierStart(s.charAt(i))) {
+                return Character.toUpperCase(s.charAt(i));
+            }
+        }
+        return '*';
     }
 
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexItem.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/IndexItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
+++ b/test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8289332 8286470
+ * @bug 8289332 8286470 8309471
  * @summary Auto-generate ids for user-defined headings
  * @library /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -59,9 +59,9 @@ public class TestAutoHeaderId extends JavadocTester {
                         /**
                          * First sentence.
                          *
-                         * <h2>First Header</h2>
+                         * <h2>1.0 First Header</h2>
                          *
-                         * <h3 id="fixed-id-1">Header with ID</h3>
+                         * <h3 id="fixed-id-1">1.1 Header with ID</h3>
                          *
                          * <h4><a id="fixed-id-2">Embedded A-Tag with ID</a></h4>
                          *
@@ -73,13 +73,13 @@ public class TestAutoHeaderId extends JavadocTester {
                          *
                          * <h4>Duplicate Text</h4>
                          *
-                         * <h2>Extra (#*!. chars</h2>
+                         * <h2>2.0 Extra (#*!. chars</h2>
                          *
                          * <h3 style="color: red;" class="some-class">Other attributes</h3>
                          *
                          * <h4></h4>
                          *
-                         * <h2>  Multi-line
+                         * <h2> 3.0 Multi-line
                          *       heading   with extra
                          *                 whitespace</h2>
                          *
@@ -94,13 +94,18 @@ public class TestAutoHeaderId extends JavadocTester {
         javadoc("-d", base.resolve("api").toString(),
                 "-sourcepath", src.toString(),
                 "--no-platform-links", "p");
+        checkIds();
+        checkSearchIndex();
+        checkHtmlIndex();
+    }
 
+    private void checkIds() {
         checkOutput("p/C.html", true,
                 """
-                    <h2 id="first-header-heading">First Header</h2>
+                    <h2 id="1-0-first-header-heading">1.0 First Header</h2>
                     """,
                 """
-                    <h3 id="fixed-id-1">Header with ID</h3>
+                    <h3 id="fixed-id-1">1.1 Header with ID</h3>
                     """,
                 """
                     <h4><a id="fixed-id-2">Embedded A-Tag with ID</a></h4>
@@ -118,7 +123,7 @@ public class TestAutoHeaderId extends JavadocTester {
                     <h4 id="duplicate-text-heading1">Duplicate Text</h4>
                     """,
                 """
-                    <h2 id="extra-chars-heading">Extra (#*!. chars</h2>
+                    <h2 id="2-0-extra-chars-heading">2.0 Extra (#*!. chars</h2>
                     """,
                 """
                     <h3 id="other-attributes-heading" style="color: red;" class="some-class">Other attributes</h3>
@@ -127,9 +132,12 @@ public class TestAutoHeaderId extends JavadocTester {
                     <h4 id="-heading"></h4>
                     """,
                 """
-                    <h2 id="multi-line-heading-with-extra-whitespace-heading">  Multi-line
+                    <h2 id="3-0-multi-line-heading-with-extra-whitespace-heading"> 3.0 Multi-line
                            heading   with extra
                                      whitespace</h2>""");
+    }
+
+    private void checkSearchIndex() {
         checkOutput("tag-search-index.js", true,
                 """
                     {"l":"Duplicate Text","h":"class p.C","d":"Section","u":"p/C.html#duplicate-text-heading"}""",
@@ -142,15 +150,87 @@ public class TestAutoHeaderId extends JavadocTester {
                 """
                     {"l":"Embedded Link Tag","h":"class p.C","d":"Section","u":"p/C.html#embedded-link-tag-heading"}""",
                 """
-                    {"l":"Extra (#*!. chars","h":"class p.C","d":"Section","u":"p/C.html#extra-chars-heading"}""",
+                    {"l":"2.0 Extra (#*!. chars","h":"class p.C","d":"Section","u":"p/C.html#2-0-extra-chars-heading"}""",
                 """
-                    {"l":"First Header","h":"class p.C","d":"Section","u":"p/C.html#first-header-heading"}""",
+                    {"l":"1.0 First Header","h":"class p.C","d":"Section","u":"p/C.html#1-0-first-header-heading"}""",
                 """
-                    {"l":"Header with ID","h":"class p.C","d":"Section","u":"p/C.html#fixed-id-1"}""",
+                    {"l":"1.1 Header with ID","h":"class p.C","d":"Section","u":"p/C.html#fixed-id-1"}""",
                 """
-                    {"l":"Multi-line heading with extra whitespace","h":"class p.C","d":"Section","u":"p/C.html\
-                    #multi-line-heading-with-extra-whitespace-heading"}""",
+                    {"l":"3.0 Multi-line heading with extra whitespace","h":"class p.C","d":"Section","u":"p/C.html\
+                    #3-0-multi-line-heading-with-extra-whitespace-heading"}""",
                 """
                     {"l":"Other attributes","h":"class p.C","d":"Section","u":"p/C.html#other-attributes-heading"}""");
+    }
+
+    private void checkHtmlIndex() {
+        // Make sure section links are not included in static index pages
+        checkOutput("index-all.html", true,
+                """
+                    <a href="#I:C">C</a>&nbsp;<a href="#I:D">D</a>&nbsp;<a href="#I:E">E</a>&nbsp;<a href="#I\
+                    :F">F</a>&nbsp;<a href="#I:H">H</a>&nbsp;<a href="#I:M">M</a>&nbsp;<a href="#I:O">O</a>&n\
+                    bsp;<a href="#I:P">P</a>&nbsp;<br><a href="allclasses-index.html">All&nbsp;Classes&nbsp;a\
+                    nd&nbsp;Interfaces</a><span class="vertical-separator">|</span><a href="allpackages-index\
+                    .html">All&nbsp;Packages</a>
+                    <h2 class="title" id="I:C">C</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html" class="type-name-link" title="class in p">C</a> - Class in <a href\
+                    ="p/package-summary.html">p</a></dt>
+                    <dd>
+                    <div class="block">First sentence.</div>
+                    </dd>
+                    </dl>
+                    <h2 class="title" id="I:D">D</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html#duplicate-text-heading" class="search-tag-link">Duplicate Text</a> \
+                    - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    <dt><a href="p/C.html#duplicate-text-heading1" class="search-tag-link">Duplicate Text</a>\
+                     - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    </dl>
+                    <h2 class="title" id="I:E">E</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html#2-0-extra-chars-heading" class="search-tag-link">2.0 Extra (#*!. ch\
+                    ars</a> - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    <dt><a href="p/C.html#fixed-id-2" class="search-tag-link">Embedded A-Tag with ID</a> - Se\
+                    arch tag in class p.C</dt>
+                    <dd>Section</dd>
+                    <dt><a href="p/C.html#embedded-code-tag-heading" class="search-tag-link">Embedded Code Ta\
+                    g</a> - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    <dt><a href="p/C.html#embedded-link-tag-heading" class="search-tag-link">Embedded Link Ta\
+                    g</a> - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    </dl>
+                    <h2 class="title" id="I:F">F</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html#1-0-first-header-heading" class="search-tag-link">1.0 First Header<\
+                    /a> - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    </dl>
+                    <h2 class="title" id="I:H">H</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html#fixed-id-1" class="search-tag-link">1.1 Header with ID</a> - Search\
+                     tag in class p.C</dt>
+                    <dd>Section</dd>
+                    </dl>
+                    <h2 class="title" id="I:M">M</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html#3-0-multi-line-heading-with-extra-whitespace-heading" class="search\
+                    -tag-link">3.0 Multi-line heading with extra whitespace</a> - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    </dl>
+                    <h2 class="title" id="I:O">O</h2>
+                    <dl class="index">
+                    <dt><a href="p/C.html#other-attributes-heading" class="search-tag-link">Other attributes<\
+                    /a> - Search tag in class p.C</dt>
+                    <dd>Section</dd>
+                    </dl>
+                    <h2 class="title" id="I:P">P</h2>
+                    <dl class="index">
+                    <dt><a href="p/package-summary.html">p</a> - package p</dt>
+                    <dd>&nbsp;</dd>
+                    </dl>""");
     }
 }


### PR DESCRIPTION
Backport of openjdk/jdk#14312 to limit first character keys in the static JavaDoc index pages to valid Java identifier start characters.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309471](https://bugs.openjdk.org/browse/JDK-8309471): Limit key characters in static index pages (**Bug** - P3)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/30/head:pull/30` \
`$ git checkout pull/30`

Update a local copy of the PR: \
`$ git checkout pull/30` \
`$ git pull https://git.openjdk.org/jdk21.git pull/30/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30`

View PR using the GUI difftool: \
`$ git pr show -t 30`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/30.diff">https://git.openjdk.org/jdk21/pull/30.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/30#issuecomment-1597012728)