### PR TITLE
8310054: ScrollPane insets are incorrect

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WScrollPanePeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WScrollPanePeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,13 @@
  */
 package sun.awt.windows;
 
-import java.awt.*;
+import java.awt.Adjustable;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.ScrollPane;
+import java.awt.ScrollPaneAdjustable;
 import java.awt.event.AdjustmentEvent;
 import java.awt.peer.ScrollPanePeer;
 
@@ -105,7 +111,6 @@ final class WScrollPanePeer extends WPanelPeer implements ScrollPanePeer {
         ScrollPane sp = (ScrollPane)target;
         Dimension vs = sp.getSize();
         setSpans(vs.width, vs.height, width, height);
-        setInsets();
     }
 
     synchronized native void setSpans(int viewWidth, int viewHeight,

--- a/src/java.desktop/windows/native/libawt/windows/awt_ScrollPane.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_ScrollPane.cpp
@@ -525,6 +525,7 @@ void AwtScrollPane::_SetSpans(void *param)
             parentWidth, parentHeight, childWidth, childHeight);
         s->RecalcSizes(parentWidth, parentHeight, childWidth, childHeight);
         s->VerifyState();
+        s->SetInsets(env);
     }
 ret:
    env->DeleteGlobalRef(self);
@@ -718,7 +719,7 @@ Java_sun_awt_windows_WScrollPanePeer_setInsets(JNIEnv *env, jobject self)
 {
     TRY
 
-    AwtToolkit::GetInstance().SyncCall(AwtScrollPane::_SetInsets,
+    AwtToolkit::GetInstance().InvokeFunction(AwtScrollPane::_SetInsets,
         env->NewGlobalRef(self));
     // global ref is deleted in _SetInsets()
 

--- a/test/jdk/java/awt/ScrollPane/ScrollPaneExtraScrollBar.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPaneExtraScrollBar.java
@@ -23,7 +23,7 @@
 
 /*
   @test
-  @bug 4152524
+  @bug 4152524 8310054
   @requires os.family=="windows"
   @summary Test that scroll pane doesn't have scroll bars visible when it is
   shown for the first time with SCROLLBARS_AS_NEEDED style
@@ -57,7 +57,7 @@ public class ScrollPaneExtraScrollBar {
             sp = new ScrollPane(ScrollPane.SCROLLBARS_AS_NEEDED);
             sp.add(new Button("TEST"));
             f.add("Center", sp);
-            f.pack();
+            // Frame must not be packed, otherwise the bug isn't reproduced
             f.setLocationRelativeTo(null);
             f.setVisible(true);
         });


### PR DESCRIPTION
This pull request contains a backport of commit [d6c2ee34](https://urldefense.com/v3/__https://github.com/openjdk/jdk/commit/d6c2ee3448a14b3e5a392aacc11ed8e47d388f80__;!!ACWV5N9M2RV99hQ!OD7LAhsqxyc5YNrxjKmpLYJCCngVm706aY3NMRMXyihGIzSIbP4H6H2INaanHemHbj9dHTsmhmOUJZhPmeXAa5_r8Rsx$) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

It fixes the regression introduced by [JDK-8297923](https://bugs.openjdk.org/browse/JDK-8297923).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310054](https://bugs.openjdk.org/browse/JDK-8310054): ScrollPane insets are incorrect (**Bug** - P3)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.org/jdk21.git pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/33.diff">https://git.openjdk.org/jdk21/pull/33.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/33#issuecomment-1597286991)