### PR TITLE
8310314: Misplaced "unnamed classes are a preview feature and are disabled by default" error

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3995,6 +3995,7 @@ public class JavacParser implements Parser {
                 }
 
                 if (isTopLevelMethodOrField) {
+                    checkSourceLevel(token.pos, Feature.UNNAMED_CLASSES);
                     defs.appendList(topLevelMethodOrFieldDeclaration(mods));
                     isUnnamedClass = true;
                 } else {
@@ -4025,8 +4026,6 @@ public class JavacParser implements Parser {
 
     // Restructure top level to be an unnamed class.
     private List<JCTree> constructUnnamedClass(List<JCTree> origDefs) {
-        checkSourceLevel(Feature.UNNAMED_CLASSES);
-
         ListBuffer<JCTree> topDefs = new ListBuffer<>();
         ListBuffer<JCTree> defs = new ListBuffer<>();
 

--- a/test/langtools/tools/javac/unnamedclass/SourceLevelErrorPosition.java
+++ b/test/langtools/tools/javac/unnamedclass/SourceLevelErrorPosition.java
@@ -1,0 +1,13 @@
+/**
+ * @test /nodynamiccopyright/
+ * @bug 8310314
+ * @summary Ensure proper error position for the "unnamed classes not supported" error
+ * @compile/fail/ref=SourceLevelErrorPosition.out -XDrawDiagnostics SourceLevelErrorPosition.java
+ */
+class Nested {}
+void main() {
+    System.err.println("");
+}
+void test() {
+    System.err.println("");
+}

--- a/test/langtools/tools/javac/unnamedclass/SourceLevelErrorPosition.out
+++ b/test/langtools/tools/javac/unnamedclass/SourceLevelErrorPosition.out
@@ -1,0 +1,2 @@
+SourceLevelErrorPosition.java:8:1: compiler.err.preview.feature.disabled.plural: (compiler.misc.feature.unnamed.classes)
+1 error


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [79069c5e](https://github.com/openjdk/jdk/commit/79069c5e748a274c45dec72aad082c31eff418d1) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jan Lahoda on 20 Jun 2023 and was reviewed by Jim Laskey.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310314](https://bugs.openjdk.org/browse/JDK-8310314): Misplaced "unnamed classes are a preview feature and are disabled by default" error (**Bug** - P3)


### Reviewers
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.org/jdk21.git pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/36.diff">https://git.openjdk.org/jdk21/pull/36.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/36#issuecomment-1598443584)