### PR TITLE
8309957: Rename JDK-8309595 test to conform

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testUnnamed/TestUnnamed.java
+++ b/test/langtools/jdk/javadoc/doclet/testUnnamed/TestUnnamed.java
@@ -28,7 +28,7 @@
  * @library  /tools/lib ../../lib
  * @modules  jdk.javadoc/jdk.javadoc.internal.tool
  * @build    toolbox.ToolBox javadoc.tester.*
- * @run main Unnamed
+ * @run main TestUnnamed
  */
 
 import java.io.File;
@@ -39,14 +39,14 @@ import java.nio.file.Path;
 import javadoc.tester.JavadocTester;
 import toolbox.ToolBox;
 
-public class Unnamed extends JavadocTester {
+public class TestUnnamed extends JavadocTester {
 
     private static final String thisVersion = System.getProperty("java.specification.version");
 
     private static final ToolBox tb = new ToolBox();
 
     public static void main(String... args) throws Exception {
-        new Unnamed().runTests();
+        new TestUnnamed().runTests();
     }
 
     @Test


### PR DESCRIPTION
As a matter of style, tests are typically in a class whose name begins Test in a directory whose name begins test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309957](https://bugs.openjdk.org/browse/JDK-8309957): Rename JDK-8309595 test to conform (**Task** - P3)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.org/jdk21.git pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/38.diff">https://git.openjdk.org/jdk21/pull/38.diff</a>

</details>
