### PR TITLE
8310105: LoongArch64 builds are broken after JDK-8304913

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/util/Architecture.java
@@ -39,6 +39,7 @@ public enum Architecture {
     AARCH64,
     ARM,
     RISCV64,
+    LOONGARCH64,
     S390,
     PPC64,
     ;
@@ -67,6 +68,14 @@ public enum Architecture {
     @ForceInline
     public static boolean isRISCV64() {
         return PlatformProps.TARGET_ARCH_IS_RISCV64;
+    }
+
+    /**
+     * {@return {@code true} if the current architecture is LOONGARCH64}
+     */
+    @ForceInline
+    public static boolean isLOONGARCH64() {
+        return PlatformProps.TARGET_ARCH_IS_LOONGARCH64;
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
+++ b/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
@@ -55,6 +55,7 @@ class PlatformProps {
     static final boolean TARGET_ARCH_IS_AARCH64 = "@@OPENJDK_TARGET_CPU@@" == "aarch64";
     static final boolean TARGET_ARCH_IS_ARM     = "@@OPENJDK_TARGET_CPU@@" == "arm";
     static final boolean TARGET_ARCH_IS_RISCV64 = "@@OPENJDK_TARGET_CPU@@" == "riscv64";
+    static final boolean TARGET_ARCH_IS_LOONGARCH64 = "@@OPENJDK_TARGET_CPU@@" == "loongarch64";
     static final boolean TARGET_ARCH_IS_S390    = "@@OPENJDK_TARGET_CPU@@" == "s390";
     static final boolean TARGET_ARCH_IS_PPC64   = "@@OPENJDK_TARGET_CPU@@" == "ppc64";
 }

--- a/test/jdk/jdk/internal/util/ArchTest.java
+++ b/test/jdk/jdk/internal/util/ArchTest.java
@@ -31,6 +31,7 @@ import static jdk.internal.util.Architecture.AARCH64;
 import static jdk.internal.util.Architecture.ARM;
 import static jdk.internal.util.Architecture.PPC64;
 import static jdk.internal.util.Architecture.RISCV64;
+import static jdk.internal.util.Architecture.LOONGARCH64;
 import static jdk.internal.util.Architecture.S390;
 import static jdk.internal.util.Architecture.X64;
 import static jdk.internal.util.Architecture.X86;
@@ -70,6 +71,7 @@ public class ArchTest {
             case "aarch64" -> AARCH64;
             case "arm" -> ARM;
             case "riscv64" -> RISCV64;
+            case "loongarch64" -> LOONGARCH64;
             case "s390x", "s390" -> S390;
             case "ppc64", "ppc64le" -> PPC64;
             default -> OTHER;
@@ -88,6 +90,7 @@ public class ArchTest {
                 Arguments.of(AARCH64, Architecture.isAARCH64()),
                 Arguments.of(ARM, Architecture.isARM()),
                 Arguments.of(RISCV64, Architecture.isRISCV64()),
+                Arguments.of(LOONGARCH64, Architecture.isLOONGARCH64()),
                 Arguments.of(S390, Architecture.isS390()),
                 Arguments.of(PPC64, Architecture.isPPC64())
         );


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310105](https://bugs.openjdk.org/browse/JDK-8310105): LoongArch64 builds are broken after JDK-8304913 (**Bug** - P2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/39/head:pull/39` \
`$ git checkout pull/39`

Update a local copy of the PR: \
`$ git checkout pull/39` \
`$ git pull https://git.openjdk.org/jdk21.git pull/39/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 39`

View PR using the GUI difftool: \
`$ git pr show -t 39`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/39.diff">https://git.openjdk.org/jdk21/pull/39.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/39#issuecomment-1599075477)