### PR TITLE
8310019: MIPS builds are broken after JDK-8304913

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/util/Architecture.java
@@ -42,6 +42,8 @@ public enum Architecture {
     LOONGARCH64,
     S390,
     PPC64,
+    MIPSEL,
+    MIPS64EL
     ;
 
     private static Architecture CURRENT_ARCH = initArch(PlatformProps.CURRENT_ARCH_STRING);
@@ -109,6 +111,22 @@ public enum Architecture {
     @ForceInline
     public static boolean isAARCH64() {
         return PlatformProps.TARGET_ARCH_IS_AARCH64;
+    }
+
+    /**
+     * {@return {@code true} if the current architecture is MIPSEL}
+     */
+    @ForceInline
+    public static boolean isMIPSEL() {
+        return PlatformProps.TARGET_ARCH_IS_MIPSEL;
+    }
+
+    /**
+     * {@return {@code true} if the current architecture is MIPS64EL}
+     */
+    @ForceInline
+    public static boolean isMIPS64EL() {
+        return PlatformProps.TARGET_ARCH_IS_MIPS64EL;
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
+++ b/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
@@ -58,4 +58,6 @@ class PlatformProps {
     static final boolean TARGET_ARCH_IS_LOONGARCH64 = "@@OPENJDK_TARGET_CPU@@" == "loongarch64";
     static final boolean TARGET_ARCH_IS_S390    = "@@OPENJDK_TARGET_CPU@@" == "s390";
     static final boolean TARGET_ARCH_IS_PPC64   = "@@OPENJDK_TARGET_CPU@@" == "ppc64";
+    static final boolean TARGET_ARCH_IS_MIPSEL  = "@@OPENJDK_TARGET_CPU@@" == "mipsel";
+    static final boolean TARGET_ARCH_IS_MIPS64EL= "@@OPENJDK_TARGET_CPU@@" == "mips64el";
 }

--- a/test/jdk/jdk/internal/util/ArchTest.java
+++ b/test/jdk/jdk/internal/util/ArchTest.java
@@ -35,6 +35,8 @@ import static jdk.internal.util.Architecture.LOONGARCH64;
 import static jdk.internal.util.Architecture.S390;
 import static jdk.internal.util.Architecture.X64;
 import static jdk.internal.util.Architecture.X86;
+import static jdk.internal.util.Architecture.MIPSEL;
+import static jdk.internal.util.Architecture.MIPS64EL;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -74,6 +76,8 @@ public class ArchTest {
             case "loongarch64" -> LOONGARCH64;
             case "s390x", "s390" -> S390;
             case "ppc64", "ppc64le" -> PPC64;
+            case "mipsel" -> MIPSEL;
+            case "mips64el" -> MIPS64EL;
             default -> OTHER;
         };
         assertEquals(Architecture.current(), arch, "mismatch in Architecture.current vs " + osArch);
@@ -92,6 +96,8 @@ public class ArchTest {
                 Arguments.of(RISCV64, Architecture.isRISCV64()),
                 Arguments.of(LOONGARCH64, Architecture.isLOONGARCH64()),
                 Arguments.of(S390, Architecture.isS390()),
+                Arguments.of(MIPSEL, Architecture.isMIPSEL()),
+                Arguments.of(MIPS64EL, Architecture.isMIPS64EL()),
                 Arguments.of(PPC64, Architecture.isPPC64())
         );
     }


### PR DESCRIPTION
Hi all,

    This pull request contains a backport of commit [33c6ec9d] from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

    The commit being backported was authored by Roger Riggs on 19 Jun 2023 and was reviewed by Paul Hohensee, Aleksey Shipilev and Ao Qi.

    Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310019](https://bugs.openjdk.org/browse/JDK-8310019): MIPS builds are broken after JDK-8304913 (**Bug** - P2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/40/head:pull/40` \
`$ git checkout pull/40`

Update a local copy of the PR: \
`$ git checkout pull/40` \
`$ git pull https://git.openjdk.org/jdk21.git pull/40/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 40`

View PR using the GUI difftool: \
`$ git pr show -t 40`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/40.diff">https://git.openjdk.org/jdk21/pull/40.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/40#issuecomment-1599195176)