### PR TITLE
8308499: Test vmTestbase/nsk/jdi/MethodExitRequest/addClassExclusionFilter/filter001/TestDescription.java failed: VMDisconnectedException

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/MethodExitRequest/addClassExclusionFilter/filter001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/MethodExitRequest/addClassExclusionFilter/filter001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,6 +74,7 @@ public class filter001 extends TestDebuggerType1 {
 
     private String classExclName1 = "java";
     private String classExclName2 = "sun";
+    private String classExclName3 = "jdk";
     private boolean methodExitReceived = false;
 
     protected void testRun() {
@@ -103,6 +104,7 @@ public class filter001 extends TestDebuggerType1 {
 
                 eventRequest1.addClassExclusionFilter(classExclName1 + "*");
                 eventRequest1.addClassExclusionFilter(classExclName2 + "*");
+                eventRequest1.addClassExclusionFilter(classExclName3 + "*");
                 eventRequest1.enable();
 
                 eventHandler.addListener(
@@ -111,7 +113,10 @@ public class filter001 extends TestDebuggerType1 {
                             if (event instanceof MethodExitEvent) {
                                 methodExitReceived = true;
                                 String str = ((MethodExitEvent)event).location().declaringType().name();
-                                if (str.indexOf(classExclName1) == 0 || str.indexOf(classExclName2) == 0) {
+                                if (str.indexOf(classExclName1) == 0 ||
+                                    str.indexOf(classExclName2) == 0 ||
+                                    str.indexOf(classExclName3) == 0)
+                                {
                                     setFailedStatus("Received unexpected MethodExitEvent for excluded class:" + str);
                                 } else {
                                     display("Received expected MethodExitEvent for " + str);


### PR DESCRIPTION
Clean backport of [JDK-8308499](https://bugs.openjdk.org/browse/JDK-8308499)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308499](https://bugs.openjdk.org/browse/JDK-8308499): Test vmTestbase/nsk/jdi/MethodExitRequest/addClassExclusionFilter/filter001/TestDescription.java failed: VMDisconnectedException (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/41/head:pull/41` \
`$ git checkout pull/41`

Update a local copy of the PR: \
`$ git checkout pull/41` \
`$ git pull https://git.openjdk.org/jdk21.git pull/41/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 41`

View PR using the GUI difftool: \
`$ git pr show -t 41`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/41.diff">https://git.openjdk.org/jdk21/pull/41.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/41#issuecomment-1599301293)