### PR TITLE
8309612: [REDO] JDK-8307153 JVMTI GetThreadState on carrier should return STATE_WAITING

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.hpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.hpp
@@ -96,8 +96,8 @@ class JvmtiEnvBase : public CHeapObj<mtInternal> {
   static jvmtiError check_thread_list(jint count, const jthread* list);
   static bool is_in_thread_list(jint count, const jthread* list, oop jt_oop);
 
-  // check if thread_oop represents a passive carrier thread
-  static bool is_passive_carrier_thread(JavaThread* java_thread, oop thread_oop) {
+  // check if thread_oop represents a thread carrying a virtual thread
+  static bool is_thread_carrying_vthread(JavaThread* java_thread, oop thread_oop) {
     return java_thread != nullptr && java_thread->jvmti_vthread() != nullptr
                                && java_thread->jvmti_vthread() != thread_oop
                                && java_thread->threadObj() == thread_oop;
@@ -180,7 +180,7 @@ class JvmtiEnvBase : public CHeapObj<mtInternal> {
   static oop current_thread_obj_or_resolve_external_guard(jthread thread);
 
   // Return true if the thread identified with a pair <jt,thr_obj> is current.
-  // A passive carrier thread is not treated as current.
+  // A thread carrying a virtual thread is not treated as current.
   static bool is_JavaThread_current(JavaThread* jt, oop thr_obj) {
     JavaThread* current = JavaThread::current();
     // jt can be null in case of a virtual thread
@@ -384,7 +384,8 @@ class JvmtiEnvBase : public CHeapObj<mtInternal> {
   // get carrier thread last java vframe
   static javaVFrame* get_cthread_last_java_vframe(JavaThread* jt, RegisterMap* reg_map);
 
-  // get ordinary thread thread state
+  // get platform thread state
+  static jint get_thread_state_base(oop thread_oop, JavaThread* jt);
   static jint get_thread_state(oop thread_oop, JavaThread* jt);
 
   // get virtual thread thread state

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/ThreadStateTest/ThreadStateTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/ThreadStateTest/ThreadStateTest.java
@@ -42,8 +42,12 @@ public class ThreadStateTest {
 
     private static native void setSingleSteppingMode(boolean enable);
     private static native void setMonitorContendedMode(boolean enable);
+    private static native void testGetThreadState(Thread thread);
+    private static native void testGetThreadListStackTraces(Thread thread);
 
     final Runnable FOO = () -> {
+        testGetThreadState(Thread.currentThread());
+        testGetThreadListStackTraces(Thread.currentThread());
         Thread.yield();
     };
 
@@ -59,7 +63,9 @@ public class ThreadStateTest {
 
             List<Thread> virtualThreads = new ArrayList<>();
             for (int i = 0; i < VTHREAD_COUNT; i++) {
-                virtualThreads.add(factory.newThread(FOO));
+                Thread vt = factory.newThread(FOO);
+                vt.setName("VT-" + i);
+                virtualThreads.add(vt);
             }
 
             for (Thread t : virtualThreads) {

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/ThreadStateTest/libThreadStateTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/ThreadStateTest/libThreadStateTest.cpp
@@ -29,6 +29,10 @@
 
 // set by Agent_OnLoad
 static jvmtiEnv* jvmti = nullptr;
+static const jint EXP_VT_STATE = JVMTI_THREAD_STATE_ALIVE | JVMTI_THREAD_STATE_RUNNABLE;
+static const jint EXP_CT_STATE = JVMTI_THREAD_STATE_ALIVE | JVMTI_THREAD_STATE_WAITING |
+                                 JVMTI_THREAD_STATE_WAITING_INDEFINITELY;
+static const jint MAX_FRAME_COUNT = 32;
 
 extern "C" {
 
@@ -38,20 +42,60 @@ SingleStep(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread,
 }
 
 static void JNICALL
-MonitorContended(jvmtiEnv* jvmti, JNIEnv* jni_env, jthread thread,
+MonitorContended(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread,
                  jobject object) {
+}
+
+static void JNICALL
+check_thread_state(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread, jint state, jint exp_state, const char* msg) {
+  if (state != exp_state) {
+    const char* tname = get_thread_name(jvmti, jni, thread);
+
+    LOG("FAILED: %p: %s: thread state: %x expected state: %x\n",
+        (void*)thread, tname, state, exp_state);
+
+    deallocate(jvmti, jni, (void*)tname);
+    jni->FatalError(msg);
+  }
 }
 
 JNIEXPORT void JNICALL
 Java_ThreadStateTest_setSingleSteppingMode(JNIEnv* jni, jclass klass, jboolean enable) {
   jvmtiError err = jvmti->SetEventNotificationMode(enable ? JVMTI_ENABLE : JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, nullptr);
-  check_jvmti_status(jni, err, "event handler: error in JVMTI SetEventNotificationMode for event JVMTI_EVENT_SINGLE_STEP");
+  check_jvmti_status(jni, err, "setSingleSteppingMode: error in JVMTI SetEventNotificationMode for JVMTI_EVENT_SINGLE_STEP");
 }
 
 JNIEXPORT void JNICALL
 Java_ThreadStateTest_setMonitorContendedMode(JNIEnv* jni, jclass klass, jboolean enable) {
   jvmtiError err = jvmti->SetEventNotificationMode(enable ? JVMTI_ENABLE : JVMTI_DISABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, nullptr);
-  check_jvmti_status(jni, err, "event handler: error in JVMTI SetEventNotificationMode for event JVMTI_EVENT_MONITOR_CONTENDED_ENTER");
+  check_jvmti_status(jni, err, "setMonitorContendedMode: error in JVMTI SetEventNotificationMode for JVMTI_EVENT_MONITOR_CONTENDED_ENTER");
+}
+
+JNIEXPORT void JNICALL
+Java_ThreadStateTest_testGetThreadState(JNIEnv* jni, jclass klass, jthread vthread) {
+  jthread cthread = get_carrier_thread(jvmti, jni, vthread);
+  jint ct_state = get_thread_state(jvmti, jni, cthread);
+  jint vt_state = get_thread_state(jvmti, jni, vthread);
+
+  check_thread_state(jvmti, jni, cthread, ct_state, EXP_CT_STATE,
+                     "Failed: unexpected carrier thread state from JVMTI GetThreadState");
+  check_thread_state(jvmti, jni, vthread, vt_state, EXP_VT_STATE,
+                     "Failed: unexpected virtual thread state from JVMTI GetThreadState");
+}
+
+JNIEXPORT void JNICALL
+Java_ThreadStateTest_testGetThreadListStackTraces(JNIEnv* jni, jclass klass, jthread vthread) {
+  jthread cthread = get_carrier_thread(jvmti, jni, vthread);
+  jthread threads[2] = { cthread, vthread };
+  jvmtiStackInfo* stackInfo = NULL;
+
+  jvmtiError err = jvmti->GetThreadListStackTraces(2, threads, MAX_FRAME_COUNT, &stackInfo);
+  check_jvmti_status(jni, err, "testGetThreadState: error in JVMTI GetThreadListStackTraces");
+
+  check_thread_state(jvmti, jni, cthread, stackInfo[0].state, EXP_CT_STATE,
+                     "Failed: unexpected carrier thread state from JVMTI GetThreadListStackTraces");
+  check_thread_state(jvmti, jni, vthread, stackInfo[1].state, EXP_VT_STATE,
+                     "Failed: unexpected virtual thread state from JVMTI GetThreadListStackTraces");
 }
 
 JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM* jvm, char* options, void* reserved) {
@@ -59,9 +103,9 @@ JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM* jvm, char* options, void* reserved) 
   jvmtiCapabilities caps;
   jvmtiError err;
 
-  printf("Agent_OnLoad started\n");
+  printf("Agent_OnLoad: started\n");
   if (jvm->GetEnv((void **) (&jvmti), JVMTI_VERSION) != JNI_OK) {
-    LOG("error in GetEnv");
+    LOG("Agent_OnLoad: error in GetEnv");
     return JNI_ERR;
   }
 
@@ -72,7 +116,7 @@ JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM* jvm, char* options, void* reserved) 
 
   err = jvmti->AddCapabilities(&caps);
   if (err != JVMTI_ERROR_NONE) {
-    LOG("error in JVMTI AddCapabilities: %d\n", err);
+    LOG("Agent_OnLoad: error in JVMTI AddCapabilities: %d\n", err);
   }
 
   memset(&callbacks, 0, sizeof(callbacks));
@@ -82,6 +126,7 @@ JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM* jvm, char* options, void* reserved) 
   if (err != JVMTI_ERROR_NONE) {
     LOG("Agent_OnLoad: Error in JVMTI SetEventCallbacks: %d\n", err);
   }
+  printf("Agent_OnLoad: finished\n");
 
   return 0;
 }


### PR DESCRIPTION
Clean backport from latest jdk repo to jdk21 for the fix of:
  8309612: [REDO] JDK-8307153 JVMTI GetThreadState on carrier should return STATE_WAITING

Testing:
 - TBD: mach5 tiers 1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309612](https://bugs.openjdk.org/browse/JDK-8309612): [REDO] JDK-8307153 JVMTI GetThreadState on carrier should return STATE_WAITING (**Bug** - P3)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.org/jdk21.git pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/43.diff">https://git.openjdk.org/jdk21/pull/43.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/43#issuecomment-1599967605)