### PR TITLE
8309549: com/sun/tools/attach/warnings/DynamicLoadWarningTest.java fails on AIX

### DIFF
--- a/test/jdk/com/sun/tools/attach/warnings/DynamicLoadWarningTest.java
+++ b/test/jdk/com/sun/tools/attach/warnings/DynamicLoadWarningTest.java
@@ -119,10 +119,13 @@ class DynamicLoadWarningTest {
         test().whenRunning(loadJvmtiAgent1)
                 .stderrShouldContain(JVMTI_AGENT_WARNING);
 
-        // dynamically load loadJvmtiAgent1 twice, should be one warning
-        test().whenRunning(loadJvmtiAgent1)
-                .whenRunning(loadJvmtiAgent1)
-                .stderrShouldContain(JVMTI_AGENT_WARNING, 1);
+        // dynamically load loadJvmtiAgent1 twice, should be one warning on platforms
+        // that can detect if an agent library was previously loaded
+        if (!Platform.isAix()) {
+            test().whenRunning(loadJvmtiAgent1)
+                    .whenRunning(loadJvmtiAgent1)
+                    .stderrShouldContain(JVMTI_AGENT_WARNING, 1);
+        }
 
         // opt-in via command line option to allow dynamic loading of agents
         test().withOpts("-XX:+EnableDynamicAgentLoading")


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309549](https://bugs.openjdk.org/browse/JDK-8309549): com/sun/tools/attach/warnings/DynamicLoadWarningTest.java fails on AIX (**Bug** - P3)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/44/head:pull/44` \
`$ git checkout pull/44`

Update a local copy of the PR: \
`$ git checkout pull/44` \
`$ git pull https://git.openjdk.org/jdk21.git pull/44/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 44`

View PR using the GUI difftool: \
`$ git pr show -t 44`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/44.diff">https://git.openjdk.org/jdk21/pull/44.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/44#issuecomment-1600333402)