### PR TITLE
8309498: [JVMCI] race in CallSiteTargetValue recording

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotObjectConstantImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotObjectConstantImpl.java
@@ -88,13 +88,15 @@ abstract class HotSpotObjectConstantImpl implements HotSpotObjectConstant {
         if (runtime().getCallSite().isInstance(this)) {
             // For ConstantCallSites, we need to read "isFrozen" before reading "target"
             // isFullyInitializedConstantCallSite() reads "isFrozen"
-            if (!isFullyInitializedConstantCallSite()) {
-                if (assumptions == null) {
-                    return null;
-                }
-                assumptions.record(new Assumptions.CallSiteTargetValue(this, readTarget()));
+            if (isFullyInitializedConstantCallSite()) {
+                return readTarget();
             }
-            return readTarget();
+            if (assumptions == null) {
+                return null;
+            }
+            HotSpotObjectConstantImpl result = readTarget();
+            assumptions.record(new Assumptions.CallSiteTargetValue(this, result));
+            return result;
         }
         return null;
     }


### PR DESCRIPTION
Backport of [JDK-8309498](https://bugs.openjdk.java.net/browse/JDK-8309498). Applies cleanly.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309498](https://bugs.openjdk.org/browse/JDK-8309498): [JVMCI] race in CallSiteTargetValue recording (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/50/head:pull/50` \
`$ git checkout pull/50`

Update a local copy of the PR: \
`$ git checkout pull/50` \
`$ git pull https://git.openjdk.org/jdk21.git pull/50/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 50`

View PR using the GUI difftool: \
`$ git pr show -t 50`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/50.diff">https://git.openjdk.org/jdk21/pull/50.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/50#issuecomment-1600598550)