### PR TITLE
8310126: C1: Missing receiver null check in Reference::get intrinsic

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1207,7 +1207,8 @@ void LIRGenerator::do_Reference_get(Intrinsic* x) {
 
   LIR_Opr result = rlock_result(x, T_OBJECT);
   access_load_at(IN_HEAP | ON_WEAK_OOP_REF, T_OBJECT,
-                 reference, LIR_OprFact::intConst(referent_offset), result);
+                 reference, LIR_OprFact::intConst(referent_offset), result,
+                 nullptr, info);
 }
 
 // Example: clazz.isInstance(object)

--- a/test/hotspot/jtreg/compiler/intrinsics/TestReferenceGetWithNull.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestReferenceGetWithNull.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+* @test
+* @bug 8310126
+* @summary Test that the Reference::get intrinsic works with a null argument.
+* @run main/othervm -XX:TieredStopAtLevel=1 -XX:CompileCommand=compileonly,*TestReferenceGetWithNull::test -Xbatch
+*                   compiler.intrinsics.TestReferenceGetWithNull
+*/
+
+package compiler.intrinsics;
+
+import java.lang.ref.WeakReference;
+
+public class TestReferenceGetWithNull {
+
+    // Declare final such that static binding at the call site is possible
+    static final class MyReference<T> extends WeakReference<T> {
+        public MyReference(T referent) {
+            super(referent);
+        }
+    }
+
+    static void test(MyReference r) {
+        try {
+            r.get();
+        } catch (Exception e) {
+            // Ignore
+        }
+    }
+
+    public static void main(String[] args) {
+        // Make sure MyReference is loaded
+        MyReference<String[]> obj = new MyReference<>(args);
+        // Trigger compilation
+        for (int i = 0; i < 50_000; ++i) {
+            test(null);
+        }
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8310126](https://bugs.openjdk.java.net/browse/JDK-8310126). Applies cleanly.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310126](https://bugs.openjdk.org/browse/JDK-8310126): C1: Missing receiver null check in Reference::get intrinsic (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/51/head:pull/51` \
`$ git checkout pull/51`

Update a local copy of the PR: \
`$ git checkout pull/51` \
`$ git pull https://git.openjdk.org/jdk21.git pull/51/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 51`

View PR using the GUI difftool: \
`$ git pr show -t 51`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/51.diff">https://git.openjdk.org/jdk21/pull/51.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/51#issuecomment-1600598302)