### PR TITLE
8309296: jdk/jfr/event/runtime/TestAgentEvent.java fails due to "missing" dynamic JavaAgent

### DIFF
--- a/test/jdk/jdk/jfr/event/runtime/TestAgentEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestAgentEvent.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import java.security.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Comparator;
 import java.util.List;
 import com.sun.tools.attach.VirtualMachine;
 
@@ -35,6 +36,7 @@ import jdk.jfr.consumer.RecordedClass;
 import jdk.jfr.consumer.RecordedClassLoader;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.Event;
+import jdk.jfr.StackTrace;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.jfr.Events;
@@ -55,19 +57,22 @@ import jdk.test.lib.jfr.TestClassLoader;
  *      jdk.jfr.event.runtime.JavaAgent
  *      JavaAgent.jar
  *
- * @run main/othervm -javaagent:JavaAgent.jar=foo=bar
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps -javaagent:JavaAgent.jar=foo=bar
  *      jdk.jfr.event.runtime.TestAgentEvent
  *      testJavaStatic
  *
- * @run main/othervm -Djdk.attach.allowAttachSelf=true
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps -Djdk.attach.allowAttachSelf=true
  *      jdk.jfr.event.runtime.TestAgentEvent
  *      testJavaDynamic
  *
- * @run main/othervm -agentlib:jdwp=transport=dt_socket,server=y,address=any,onjcmd=y
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps -agentlib:jdwp=transport=dt_socket,server=y,address=any,onjcmd=y
  *      jdk.jfr.event.runtime.TestAgentEvent
  *      testNativeStatic
  */
 public final class TestAgentEvent {
+    @StackTrace(false)
+    static class RecordingInterval extends Event {
+    }
     private static final String JAVA_AGENT_JAR = "JavaAgent.jar";
 
     public static void main(String[] args) throws Throwable {
@@ -81,17 +86,22 @@ public final class TestAgentEvent {
 
     private static void testJavaStatic() throws Throwable {
         try (Recording r = new Recording()) {
-            r.enable(EventNames.JavaAgent);
+            r.enable(EventNames.JavaAgent).with("period", "endChunk");
             r.start();
+            RecordingInterval intervalEvent = new RecordingInterval();
+            intervalEvent.commit();
             r.stop();
             List<RecordedEvent> events = Events.fromRecording(r);
-            RecordedEvent e = events.get(0);
+            events.sort(Comparator.comparing(RecordedEvent::getEndTime));
+            RecordedEvent interval = events.getFirst();
+            System.out.println(interval);
+            RecordedEvent e = events.get(1);
             System.out.println(e);
             Events.assertField(e, "name").equal(JAVA_AGENT_JAR);
             Events.assertField(e, "options").equal("foo=bar");
             Events.assertField(e, "dynamic").equal(false);
             Instant initializationTime = e.getInstant("initializationTime");
-            if (initializationTime.isAfter(r.getStartTime())) {
+            if (initializationTime.isAfter(interval.getStartTime())) {
                 throw new Exception("Expected a static JavaAgent to be initialized before recording start");
             }
             Events.assertField(e, "initializationDuration").atLeast(0L);
@@ -100,17 +110,22 @@ public final class TestAgentEvent {
 
     private static void testNativeStatic() throws Throwable {
         try (Recording r = new Recording()) {
-            r.enable(EventNames.NativeAgent);
+            r.enable(EventNames.NativeAgent).with("period", "endChunk");
             r.start();
+            RecordingInterval intervalEvent = new RecordingInterval();
+            intervalEvent.commit();
             r.stop();
             List<RecordedEvent> events = Events.fromRecording(r);
-            RecordedEvent e = events.get(0);
+            events.sort(Comparator.comparing(RecordedEvent::getEndTime));
+            RecordedEvent interval = events.getFirst();
+            System.out.println(interval);
+            RecordedEvent e = events.get(1);
             System.out.println(e);
             Events.assertField(e, "name").equal("jdwp");
             Events.assertField(e, "options").equal("transport=dt_socket,server=y,address=any,onjcmd=y");
             Events.assertField(e, "dynamic").equal(false);
             Instant initializationTime = e.getInstant("initializationTime");
-            if (initializationTime.isAfter(r.getStartTime())) {
+            if (initializationTime.isAfter(interval.getStartTime())) {
                 throw new Exception("Expected a static NativeAgent to be initialized before recording start");
             }
             Events.assertField(e, "initializationDuration").atLeast(0L);
@@ -119,8 +134,10 @@ public final class TestAgentEvent {
 
     private static void testJavaDynamic() throws Throwable {
         try (Recording r = new Recording()) {
-            r.enable(EventNames.JavaAgent);
+            r.enable(EventNames.JavaAgent).with("period", "endChunk");
             r.start();
+            RecordingInterval intervalEvent = new RecordingInterval();
+            intervalEvent.begin();
             long pid = ProcessHandle.current().pid();
             VirtualMachine vm = VirtualMachine.attach(Long.toString(pid));
             vm.loadAgent(JAVA_AGENT_JAR, "bar=baz");
@@ -132,15 +149,19 @@ public final class TestAgentEvent {
             vm.loadAgent(JAVA_AGENT_JAR, "");
             vm.loadAgent(JAVA_AGENT_JAR, "=");
             vm.detach();
+            intervalEvent.commit();
             r.stop();
             List<RecordedEvent> events = Events.fromRecording(r);
-            for (RecordedEvent e : events) {
+            events.sort(Comparator.comparing(RecordedEvent::getEndTime));
+            RecordedEvent interval = events.getFirst();
+            System.out.println(interval);
+            for (RecordedEvent e : events.subList(1, events.size())) {
                 System.out.println(e);
                 Instant initializationTime = e.getInstant("initializationTime");
-                if (initializationTime.isBefore(r.getStartTime())) {
+                if (initializationTime.isBefore(interval.getStartTime())) {
                     throw new Exception("Expected a dynamic JavaAgent to be initialized after recording start");
                 }
-                if (initializationTime.isAfter(r.getStopTime())) {
+                if (initializationTime.isAfter(interval.getEndTime())) {
                     throw new Exception("Expected a dynamic JavaAgent to be initialized before recording stop");
                 }
                 Duration initializationDuration = e.getDuration("initializationDuration");
@@ -152,10 +173,10 @@ public final class TestAgentEvent {
                 }
                 Events.assertField(e, "name").equal(JAVA_AGENT_JAR);
             }
-            Events.assertField(events.get(0), "options").equal("bar=baz");
-            Events.assertField(events.get(1), "options").equal(null);
-            Events.assertField(events.get(2), "options").equal("");
-            Events.assertField(events.get(3), "options").equal("=");
+            Events.assertField(events.get(1), "options").equal("bar=baz");
+            Events.assertField(events.get(2), "options").equal(null);
+            Events.assertField(events.get(3), "options").equal("");
+            Events.assertField(events.get(4), "options").equal("=");
         }
     }
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309296](https://bugs.openjdk.org/browse/JDK-8309296): jdk/jfr/event/runtime/TestAgentEvent.java fails due to "missing" dynamic JavaAgent (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.org/jdk21.git pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/54.diff">https://git.openjdk.org/jdk21/pull/54.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/54#issuecomment-1601139409)