### PR TITLE
8309959: JFR: Display N/A for missing data amount

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
@@ -121,11 +121,13 @@ public final class Utils {
         }
     }
 
-    // handle Long.MIN_VALUE as a special case since its absolute value is negative
     private static String formatDataAmount(String formatter, long amount) {
-        int exp = (amount == Long.MIN_VALUE) ? 6 : (int) (Math.log(Math.abs(amount)) / Math.log(1024));
-        char unitPrefix = "kMGTPE".charAt(exp - 1);
-        return String.format(formatter, amount / Math.pow(1024, exp), unitPrefix);
+        if (amount == Long.MIN_VALUE) {
+            return "N/A";
+        }
+        int exp = (int) (Math.log(Math.abs(amount)) / Math.log(1024));
+        char unit = "kMGTPE".charAt(exp - 1);
+        return String.format(formatter, amount / Math.pow(1024, exp), unit);
     }
 
     public static String formatBytesCompact(long bytes) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueFormatter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueFormatter.java
@@ -146,11 +146,13 @@ public final class ValueFormatter {
         return name;
     }
 
-    // handle Long.MIN_VALUE as a special case since its absolute value is negative
     private static String formatDataAmount(String formatter, long amount) {
-        int exp = (amount == Long.MIN_VALUE) ? 6 : (int) (Math.log(Math.abs(amount)) / Math.log(1024));
-        char unitPrefix = "kMGTPE".charAt(exp - 1);
-        return String.format(formatter, amount / Math.pow(1024, exp), unitPrefix);
+        if (amount == Long.MIN_VALUE) {
+            return "N/A";
+        }
+        int exp = (int) (Math.log(Math.abs(amount)) / Math.log(1024));
+        char unit = "kMGTPE".charAt(exp - 1);
+        return String.format(formatter, amount / Math.pow(1024, exp), unit);
     }
 
     public static String formatBytesCompact(long bytes) {


### PR DESCRIPTION
Hi!

This pull request contains a backport of commit [9872a141](https://github.com/openjdk/jdk/commit/9872a14192ce3964b934c19ab685342ffd396986) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Erik Gahlin on 14 Jun 2023 and was reviewed by Markus Grönlund and Thomas Stuefe.

This is a follow-up to [JDK-8309550](https://github.com/openjdk/jdk17u-dev/pull/1438) which was integrated *before* RDP1, so backporting this one also as a matter of consistency.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309959](https://bugs.openjdk.org/browse/JDK-8309959): JFR: Display N/A for missing data amount (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/56/head:pull/56` \
`$ git checkout pull/56`

Update a local copy of the PR: \
`$ git checkout pull/56` \
`$ git pull https://git.openjdk.org/jdk21.git pull/56/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 56`

View PR using the GUI difftool: \
`$ git pr show -t 56`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/56.diff">https://git.openjdk.org/jdk21/pull/56.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/56#issuecomment-1602724182)