### PR TITLE
8309670: java -help output for --module-path / -p is incomplete

### DIFF
--- a/src/java.base/share/classes/sun/launcher/resources/launcher.properties
+++ b/src/java.base/share/classes/sun/launcher/resources/launcher.properties
@@ -50,12 +50,14 @@ java.launcher.opt.footer = \
 \                  and ZIP archives to search for class files.\n\
 \    -p <module path>\n\
 \    --module-path <module path>...\n\
-\                  A {0} separated list of directories, each directory\n\
-\                  is a directory of modules.\n\
+\                  A {0} separated list of elements, each element is a file path\n\
+\                  to a module or a directory containing modules. Each module is either\n\
+\                  a modular JAR or an exploded-module directory.\n\
 \    --upgrade-module-path <module path>...\n\
-\                  A {0} separated list of directories, each directory\n\
-\                  is a directory of modules that replace upgradeable\n\
-\                  modules in the runtime image\n\
+\                  A {0} separated list of elements, each element is a file path\n\
+\                  to a module or a directory containing modules to replace\n\
+\                  upgradeable modules in the runtime image. Each module is either\n\
+\                  a modular JAR or an exploded-module directory.\n\
 \    --add-modules <module name>[,<module name>...]\n\
 \                  root modules to resolve in addition to the initial module.\n\
 \                  <module name> can also be ALL-DEFAULT, ALL-SYSTEM,\n\

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -530,20 +530,25 @@ The value \[dq]disabled\[dq] disables finalization, so that no
 finalizers are invoked.
 .TP
 \f[V]--module-path\f[R] \f[I]modulepath\f[R]... or \f[V]-p\f[R] \f[I]modulepath\f[R]
-Specifies a list of directories in which each directory is a directory
-of modules.
+Specifies where to find application modules with a list of path elements.
+The elements of a module path can be a file path to a module or a directory
+containing modules. Each module is either a modular JAR or an
+exploded-module directory.
 .RS
 .PP
-On Windows, semicolons (\f[V];\f[R]) separate directories in this list;
+On Windows, semicolons (\f[V];\f[R]) separate path elements in this list;
 on other platforms it is a colon (\f[V]:\f[R]).
 .RE
 .TP
 \f[V]--upgrade-module-path\f[R] \f[I]modulepath\f[R]...
-Specifies a list of directories in which each directory is a directory
-of modules that replace upgradeable modules in the runtime image.
+Specifies where to find module replacements of upgradeable modules in the
+runtime image with a list of path elements.
+The elements of a module path can be a file path to a module or a directory
+containing modules. Each module is either a modular JAR or an
+exploded-module directory.
 .RS
 .PP
-On Windows, semicolons (\f[V];\f[R]) separate directories in this list;
+On Windows, semicolons (\f[V];\f[R]) separate path elements in this list;
 on other platforms it is a colon (\f[V]:\f[R]).
 .RE
 .TP


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [4bf78162](https://github.com/openjdk/jdk/commit/4bf78162c52564645af79b8324b69d89102dc024) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christian Stein on 23 Jun 2023 and was reviewed by Mandy Chung and Alan Bateman.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309670](https://bugs.openjdk.org/browse/JDK-8309670): java -help output for --module-path / -p is incomplete (**Bug** - P3)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.org/jdk21.git pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/57.diff">https://git.openjdk.org/jdk21/pull/57.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/57#issuecomment-1604159305)