### PR TITLE
8309733: [macOS, Accessibility] VoiceOver: Incorrect announcements of JRadioButton

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -182,17 +182,23 @@ class CAccessible extends CFRetainedResource implements Accessible {
 
                     // Do send check box state changes to native side
                     if (thisRole == AccessibleRole.CHECK_BOX) {
-                        valueChanged(ptr);
+                        if (newValue != null && !newValue.equals(oldValue)) {
+                            valueChanged(ptr);
+                        }
                     }
 
                     // Do send radio button state changes to native side
                     if (thisRole == AccessibleRole.RADIO_BUTTON) {
-                        valueChanged(ptr);
+                        if (newValue != null && !newValue.equals(oldValue)) {
+                            valueChanged(ptr);
+                        }
                     }
 
                     // Do send toggle button state changes to native side
                     if (thisRole == AccessibleRole.TOGGLE_BUTTON) {
-                        valueChanged(ptr);
+                        if (newValue != null && !newValue.equals(oldValue)) {
+                            valueChanged(ptr);
+                        }
                     }
                 } else if (name.equals(ACCESSIBLE_NAME_PROPERTY)) {
                     //for now trigger only for JTabbedPane.


### PR DESCRIPTION
Backport of a regression fix for JDK-8309733

Changes applied cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309733](https://bugs.openjdk.org/browse/JDK-8309733): [macOS, Accessibility] VoiceOver: Incorrect announcements of JRadioButton (**Bug** - P2)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/59/head:pull/59` \
`$ git checkout pull/59`

Update a local copy of the PR: \
`$ git checkout pull/59` \
`$ git pull https://git.openjdk.org/jdk21.git pull/59/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 59`

View PR using the GUI difftool: \
`$ git pr show -t 59`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/59.diff">https://git.openjdk.org/jdk21/pull/59.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/59#issuecomment-1604718459)