### PR TITLE
8310676: add note about unnamed module to Elements.getAllModuleElements

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -254,6 +254,11 @@ public interface Elements {
      * @implSpec The default implementation of this method returns
      * an empty set.
      *
+     * @apiNote
+     * When an environment includes modules, both named modules and
+     * {@linkplain ModuleElement#isUnnamed() unnamed modules} may be
+     * returned.
+     *
      * @return the known module elements, or an empty set if there are no modules
      * @see #getModuleElement(CharSequence)
      * @since 9


### PR DESCRIPTION
Doc-only backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310676](https://bugs.openjdk.org/browse/JDK-8310676): add note about unnamed module to Elements.getAllModuleElements (**Enhancement** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/61/head:pull/61` \
`$ git checkout pull/61`

Update a local copy of the PR: \
`$ git checkout pull/61` \
`$ git pull https://git.openjdk.org/jdk21.git pull/61/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 61`

View PR using the GUI difftool: \
`$ git pr show -t 61`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/61.diff">https://git.openjdk.org/jdk21/pull/61.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/61#issuecomment-1605008237)