### PR TITLE
8310242: Clarify the name parameter to Class::forName

### DIFF
--- a/test/jdk/java/lang/Class/forName/ForNameNames.java
+++ b/test/jdk/java/lang/Class/forName/ForNameNames.java
@@ -43,7 +43,7 @@ public class ForNameNames {
                 Arguments.of("java.lang.String", String.class),
                 Arguments.of("[Ljava.lang.String;", String[].class),
                 Arguments.of("ForNameNames$Inner", Inner.class),
-                Arguments.of("[LForNameNames$Inner;", Inner.class),
+                Arguments.of("[LForNameNames$Inner;", Inner[].class),
                 Arguments.of("[[I", int[][].class)
         );
     }

--- a/test/jdk/java/lang/Class/forName/ForNameNames.java
+++ b/test/jdk/java/lang/Class/forName/ForNameNames.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8310242
+ * @run junit ForNameNames
+ * @summary Verify class names for Class.forName
+ */
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ForNameNames {
+    static class Inner {}
+    static Stream<Arguments> testCases() {
+        return Stream.of(
+                Arguments.of("java.lang.String", String.class),
+                Arguments.of("[Ljava.lang.String;", String[].class),
+                Arguments.of("ForNameNames$Inner", Inner.class),
+                Arguments.of("[LForNameNames$Inner;", Inner.class),
+                Arguments.of("[[I", int[][].class)
+        );
+    }
+
+    /*
+     * Test 1-arg and 3-arg Class::forName.  Class::getName on the returned
+     * Class object returns the name passed to Class::forName.
+     */
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void testForName(String cn, Class<?> expected) throws ClassNotFoundException {
+        ClassLoader loader = ForNameNames.class.getClassLoader();
+        Class<?> c1 = Class.forName(cn, false, loader);
+        assertEquals(expected, c1);
+        assertEquals(cn, c1.getName());
+
+        Class<?> c2 = Class.forName(cn);
+        assertEquals(expected, c2);
+        assertEquals(cn, c2.getName());
+    }
+
+    static Stream<Arguments> invalidNames() {
+        return Stream.of(
+                Arguments.of("I"),                   // primitive type
+                Arguments.of("int[]"),               // fully-qualified name of int array
+                Arguments.of("ForNameNames.Inner"),  // fully-qualified name of nested type
+                Arguments.of("[java.lang.String"),   // missing L and ;
+                Arguments.of("[Ljava.lang.String"),  // missing ;
+                Arguments.of("[Ljava/lang/String;")  // type descriptor
+
+        );
+    }
+    @ParameterizedTest
+    @MethodSource("invalidNames")
+    void testInvalidNames(String cn) {
+        ClassLoader loader = ForNameNames.class.getClassLoader();
+        assertThrows(ClassNotFoundException.class, () -> Class.forName(cn, false, loader));
+    }
+
+    @Test
+    void testModule() {
+        // Class.forName(Module, String) does not allow class name for array types
+        Class<?> c = Class.forName(Object.class.getModule(), "[Ljava.lang.String;");
+        assertNull(c);
+    }
+
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [7db2f087](https://github.com/openjdk/jdk/commit/7db2f08756b0aa1d79cdd2356ed42aa5ab8bc58b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Mandy Chung on 26 Jun 2023 and was reviewed by Roger Riggs, Chen Liang, Alan Bateman and David Holmes.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8310244](https://bugs.openjdk.org/browse/JDK-8310244) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8310242](https://bugs.openjdk.org/browse/JDK-8310242): Clarify the name parameter to Class::forName (**Bug** - P4)
 * [JDK-8310922](https://bugs.openjdk.org/browse/JDK-8310922): java/lang/Class/forName/ForNameNames.java fails after being added by JDK-8310242 (**Bug** - P2)
 * [JDK-8310244](https://bugs.openjdk.org/browse/JDK-8310244): Clarify the name parameter to Class::forName (**CSR**)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/65/head:pull/65` \
`$ git checkout pull/65`

Update a local copy of the PR: \
`$ git checkout pull/65` \
`$ git pull https://git.openjdk.org/jdk21.git pull/65/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 65`

View PR using the GUI difftool: \
`$ git pr show -t 65`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/65.diff">https://git.openjdk.org/jdk21/pull/65.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/65#issuecomment-1608203816)