### PR TITLE
8310838: Correct range notations in MethodTypeDesc specification

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/MethodTypeDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/MethodTypeDesc.java
@@ -119,7 +119,7 @@ public sealed interface MethodTypeDesc
      * @param index the index of the parameter to retrieve
      * @return a {@link ClassDesc} describing the desired parameter type
      * @throws IndexOutOfBoundsException if the index is outside the half-open
-     * range {[0, parameterCount())}
+     * range {@code [0, parameterCount())}
      */
     ClassDesc parameterType(int index);
 
@@ -156,7 +156,7 @@ public sealed interface MethodTypeDesc
      * @return a {@linkplain MethodTypeDesc} describing the desired method type
      * @throws NullPointerException if any argument is {@code null}
      * @throws IndexOutOfBoundsException if the index is outside the half-open
-     * range {[0, parameterCount)}
+     * range {@code [0, parameterCount)}
      */
     MethodTypeDesc changeParameterType(int index, ClassDesc paramType);
 
@@ -183,7 +183,7 @@ public sealed interface MethodTypeDesc
      * @return a {@linkplain MethodTypeDesc} describing the desired method type
      * @throws NullPointerException if any argument or its contents are {@code null}
      * @throws IndexOutOfBoundsException if {@code pos} is outside the closed
-     * range {[0, parameterCount]}
+     * range {@code [0, parameterCount]}
      * @throws IllegalArgumentException if any element of {@code paramTypes}
      * is a {@link ClassDesc} for {@code void}
      */


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [a197ee79](https://github.com/openjdk/jdk/commit/a197ee797b3580d9f85636522587d3f6418dff6a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository. This is a doc-only typo fix.

The commit being backported was authored by Chen Liang on 26 Jun 2023 and was reviewed by Mandy Chung.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310838](https://bugs.openjdk.org/browse/JDK-8310838): Correct range notations in MethodTypeDesc specification (**Bug** - P4)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/66/head:pull/66` \
`$ git checkout pull/66`

Update a local copy of the PR: \
`$ git checkout pull/66` \
`$ git pull https://git.openjdk.org/jdk21.git pull/66/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 66`

View PR using the GUI difftool: \
`$ git pr show -t 66`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/66.diff">https://git.openjdk.org/jdk21/pull/66.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/66#issuecomment-1608412946)