### PR TITLE
8310194: Generational ZGC: Lock-order asserts in JVMTI IterateThroughHeap

### DIFF
--- a/src/hotspot/share/gc/z/zHeap.cpp
+++ b/src/hotspot/share/gc/z/zHeap.cpp
@@ -293,19 +293,19 @@ bool ZHeap::is_allocating(zaddress addr) const {
 
 void ZHeap::object_iterate(ObjectClosure* object_cl, bool visit_weaks) {
   assert(SafepointSynchronize::is_at_safepoint(), "Should be at safepoint");
-  ZHeapIterator iter(1 /* nworkers */, visit_weaks);
+  ZHeapIterator iter(1 /* nworkers */, visit_weaks, false /* for_verify */);
   iter.object_iterate(object_cl, 0 /* worker_id */);
 }
 
-void ZHeap::object_and_field_iterate(ObjectClosure* object_cl, OopFieldClosure* field_cl, bool visit_weaks) {
+void ZHeap::object_and_field_iterate_for_verify(ObjectClosure* object_cl, OopFieldClosure* field_cl, bool visit_weaks) {
   assert(SafepointSynchronize::is_at_safepoint(), "Should be at safepoint");
-  ZHeapIterator iter(1 /* nworkers */, visit_weaks);
+  ZHeapIterator iter(1 /* nworkers */, visit_weaks, true /* for_verify */);
   iter.object_and_field_iterate(object_cl, field_cl, 0 /* worker_id */);
 }
 
 ParallelObjectIteratorImpl* ZHeap::parallel_object_iterator(uint nworkers, bool visit_weaks) {
   assert(SafepointSynchronize::is_at_safepoint(), "Should be at safepoint");
-  return new ZHeapIterator(nworkers, visit_weaks);
+  return new ZHeapIterator(nworkers, visit_weaks, false /* for_verify */);
 }
 
 void ZHeap::serviceability_initialize() {

--- a/src/hotspot/share/gc/z/zHeap.hpp
+++ b/src/hotspot/share/gc/z/zHeap.hpp
@@ -118,7 +118,7 @@ public:
 
   // Iteration
   void object_iterate(ObjectClosure* object_cl, bool visit_weaks);
-  void object_and_field_iterate(ObjectClosure* object_cl, OopFieldClosure* field_cl, bool visit_weaks);
+  void object_and_field_iterate_for_verify(ObjectClosure* object_cl, OopFieldClosure* field_cl, bool visit_weaks);
   ParallelObjectIteratorImpl* parallel_object_iterator(uint nworkers, bool visit_weaks);
 
   void threads_do(ThreadClosure* tc) const;

--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -426,7 +426,7 @@ void ZVerify::objects(bool verify_weaks) {
   threads_start_processing();
 
   ZVerifyObjectClosure object_cl(verify_weaks);
-  ZHeap::heap()->object_and_field_iterate(&object_cl, &object_cl, verify_weaks);
+  ZHeap::heap()->object_and_field_iterate_for_verify(&object_cl, &object_cl, verify_weaks);
 }
 
 void ZVerify::before_zoperation() {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310194](https://bugs.openjdk.org/browse/JDK-8310194): Generational ZGC: Lock-order asserts in JVMTI IterateThroughHeap (**Bug** - P2)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.org/jdk21.git pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/69.diff">https://git.openjdk.org/jdk21/pull/69.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/69#issuecomment-1609035558)