### PR TITLE
8310182: DateTimeFormatter date formats (ISO_LOCAL_DATE) separated with hyphen, not dash

### DIFF
--- a/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -782,10 +782,10 @@ public final class DateTimeFormatter {
      * <li>Four digits or more for the {@link ChronoField#YEAR year}.
      * Years in the range 0000 to 9999 will be pre-padded by zero to ensure four digits.
      * Years outside that range will have a prefixed positive or negative symbol.
-     * <li>A dash
+     * <li>A hyphen ('HYPHEN-MINUS', U+002D)
      * <li>Two digits for the {@link ChronoField#MONTH_OF_YEAR month-of-year}.
      *  This is pre-padded by zero to ensure two digits.
-     * <li>A dash
+     * <li>A hyphen ('HYPHEN-MINUS', U+002D)
      * <li>Two digits for the {@link ChronoField#DAY_OF_MONTH day-of-month}.
      *  This is pre-padded by zero to ensure two digits.
      * </ul>
@@ -1115,7 +1115,7 @@ public final class DateTimeFormatter {
      * <li>Four digits or more for the {@link ChronoField#YEAR year}.
      * Years in the range 0000 to 9999 will be pre-padded by zero to ensure four digits.
      * Years outside that range will have a prefixed positive or negative symbol.
-     * <li>A dash
+     * <li>A hyphen ('HYPHEN-MINUS', U+002D)
      * <li>Three digits for the {@link ChronoField#DAY_OF_YEAR day-of-year}.
      *  This is pre-padded by zero to ensure three digits.
      * <li>If the offset is not available to format or parse then the format is complete.
@@ -1155,11 +1155,11 @@ public final class DateTimeFormatter {
      * <li>Four digits or more for the {@link IsoFields#WEEK_BASED_YEAR week-based-year}.
      * Years in the range 0000 to 9999 will be pre-padded by zero to ensure four digits.
      * Years outside that range will have a prefixed positive or negative symbol.
-     * <li>A dash
+     * <li>A hyphen ('HYPHEN-MINUS', U+002D)
      * <li>The letter 'W'. Parsing is case insensitive.
      * <li>Two digits for the {@link IsoFields#WEEK_OF_WEEK_BASED_YEAR week-of-week-based-year}.
      *  This is pre-padded by zero to ensure three digits.
-     * <li>A dash
+     * <li>A hyphen ('HYPHEN-MINUS', U+002D)
      * <li>One digit for the {@link ChronoField#DAY_OF_WEEK day-of-week}.
      *  The value run from Monday (1) to Sunday (7).
      * <li>If the offset is not available to format or parse then the format is complete.


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ec45bd64](https://github.com/openjdk/jdk/commit/ec45bd64d504d579aef54c924fb8ca75a944036f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Naoto Sato on 27 Jun 2023 and was reviewed by Roger Riggs, Joe Darcy, Iris Clark and Lance Andersen.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310182](https://bugs.openjdk.org/browse/JDK-8310182): DateTimeFormatter date formats (ISO_LOCAL_DATE) separated with hyphen, not dash (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/70/head:pull/70` \
`$ git checkout pull/70`

Update a local copy of the PR: \
`$ git checkout pull/70` \
`$ git pull https://git.openjdk.org/jdk21.git pull/70/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 70`

View PR using the GUI difftool: \
`$ git pr show -t 70`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/70.diff">https://git.openjdk.org/jdk21/pull/70.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/70#issuecomment-1609925734)