### PR TITLE
8310975: java.util.FormatItemModifier should not be protected

### DIFF
--- a/src/java.base/share/classes/java/util/FormatItem.java
+++ b/src/java.base/share/classes/java/util/FormatItem.java
@@ -422,7 +422,7 @@ class FormatItem {
         }
     }
 
-    protected static abstract sealed class FormatItemModifier implements FormatConcatItem
+    static abstract sealed class FormatItemModifier implements FormatConcatItem
         permits FormatItemFillLeft,
                 FormatItemFillRight
     {


### PR DESCRIPTION
The nested class is incorrectly marked as protected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310975](https://bugs.openjdk.org/browse/JDK-8310975): java.util.FormatItemModifier should not be protected (**Bug** - P3)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/72/head:pull/72` \
`$ git checkout pull/72`

Update a local copy of the PR: \
`$ git checkout pull/72` \
`$ git pull https://git.openjdk.org/jdk21.git pull/72/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 72`

View PR using the GUI difftool: \
`$ git pr show -t 72`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/72.diff">https://git.openjdk.org/jdk21/pull/72.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/72#issuecomment-1610066973)