### PR TITLE
8311034: Fix typo in javac man page

### DIFF
--- a/src/jdk.compiler/share/man/javac.1
+++ b/src/jdk.compiler/share/man/javac.1
@@ -1706,8 +1706,8 @@ The search path can be specified with the
 \f[B]\f[VB]-processorpath\f[B]\f[R] option.
 If no path is specified, then the user class path is used.
 Processors are located by means of service provider-configuration files
-named \f[V]META-INF/services/javax.annotation.processing\f[R].
-Processor on the search path.
+named \f[V]META-INF/services/javax.annotation.processing.Processor\f[R]
+on the search path.
 Such files should contain the names of any annotation processors to be
 used, listed one per line.
 Alternatively, processors can be specified explicitly, using the


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [f17bfeec](https://github.com/openjdk/jdk/commit/f17bfeec61b753eb0eb8a48df9bf5ccc3bcd9eb3) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Pavel Rappo on 28 Jun 2023 and was reviewed by Hannes Wallnöfer.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311034](https://bugs.openjdk.org/browse/JDK-8311034): Fix typo in javac man page (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/76/head:pull/76` \
`$ git checkout pull/76`

Update a local copy of the PR: \
`$ git checkout pull/76` \
`$ git pull https://git.openjdk.org/jdk21.git pull/76/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 76`

View PR using the GUI difftool: \
`$ git pr show -t 76`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/76.diff">https://git.openjdk.org/jdk21/pull/76.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/76#issuecomment-1611480582)