### PR TITLE
8310130: C2: assert(false) failed: scalar_input is neither phi nor a matchin reduction

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -4224,7 +4224,8 @@ void PhaseIdealLoop::move_unordered_reduction_out_of_loop(IdealLoopTree* loop) {
           if (use != phi && ctrl_or_self(use) == cl) {
             DEBUG_ONLY( current->dump(-1); )
             assert(false, "reduction has use inside loop");
-            break; // Chain traversal fails.
+            // Should not be allowed by SuperWord::mark_reductions
+            return; // bail out of optimization
           }
         }
       } else {
@@ -4245,8 +4246,9 @@ void PhaseIdealLoop::move_unordered_reduction_out_of_loop(IdealLoopTree* loop) {
         current = nullptr;
         break; // Success.
       } else {
-        DEBUG_ONLY( current->dump(1); )
-        assert(false, "scalar_input is neither phi nor a matchin reduction");
+        // scalar_input is neither phi nor a matching reduction
+        // Can for example be scalar reduction when we have
+        // partial vectorization.
         break; // Chain traversal fails.
       }
     }

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug JDK-8310130
+ * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
+ *          Here a case with partial vectorization of the reduction.
+ * @requires vm.bits == "64"
+ * @library /test/lib /
+ * @run driver compiler.loopopts.superword.TestUnorderedReductionPartialVectorization
+ */
+
+package compiler.loopopts.superword;
+
+import compiler.lib.ir_framework.*;
+
+public class TestUnorderedReductionPartialVectorization {
+    static final int RANGE = 1024;
+    static final int ITER  = 10;
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Run(test = {"test1"})
+    @Warmup(0)
+    public void runTests() throws Exception {
+        int[] data = new int[RANGE];
+
+        init(data);
+        for (int i = 0; i < ITER; i++) {
+            long r1 = test1(data, i);
+            long r2 = ref1(data, i);
+            if (r1 != r2) {
+                throw new RuntimeException("Wrong result test1: " + r1 + " != " + r2);
+            }
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.LOAD_VECTOR, "> 0",
+                  IRNode.OR_REDUCTION_V, "> 0",},
+        applyIfCPUFeatureOr = {"avx2", "true"})
+    static long test1(int[] data, long sum) {
+        for (int i = 0; i < data.length; i++) {
+            // Mixing int and long ops means we only end up allowing half of the int
+            // loads in one pack, and we have two int packs. The first pack has one
+            // of the pairs missing because of the store, which creates a dependency.
+            // The first pack is rejected and left as scalar, the second pack succeeds
+            // with vectorization. That means we have a mixed scalar/vector reduction
+            // chain. This way it is possible that a vector-reduction has a scalar
+            // reduction as input, which is neigher a phi nor a vector reduction.
+            // In such a case, we must bail out of the optimization in
+            // PhaseIdealLoop::move_unordered_reduction_out_of_loop
+            int v = data[i]; // int read
+            data[0] = 0;     // ruin the first pack
+            sum |= v;        // long reduction
+        }
+        return sum;
+    }
+
+    static long ref1(int[] data, long sum) {
+        for (int i = 0; i < data.length; i++) {
+            int v = data[i];
+            data[0] = 0;
+            sum |= v;
+        }
+        return sum;
+    }
+
+    static void init(int[] data) {
+        for (int i = 0; i < RANGE; i++) {
+            data[i] = i + 1;
+        }
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8310130](https://bugs.openjdk.java.net/browse/JDK-8310130). Applies cleanly.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310130](https://bugs.openjdk.org/browse/JDK-8310130): C2: assert(false) failed: scalar_input is neither phi nor a matchin reduction (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/77/head:pull/77` \
`$ git checkout pull/77`

Update a local copy of the PR: \
`$ git checkout pull/77` \
`$ git pull https://git.openjdk.org/jdk21.git pull/77/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 77`

View PR using the GUI difftool: \
`$ git pr show -t 77`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/77.diff">https://git.openjdk.org/jdk21/pull/77.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/77#issuecomment-1611581873)