### PR TITLE
8310405: Linker.Option.firstVariadicArg should specify which index values are valid

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -416,8 +416,8 @@ import java.util.stream.Stream;
  * The native linker only supports linking the specialized form of a variadic function. A variadic function in its specialized
  * form can be linked using a function descriptor describing the specialized form. Additionally, the
  * {@link Linker.Option#firstVariadicArg(int)} linker option must be provided to indicate the first variadic parameter in
- * the parameter list. The corresponding argument layout, and all following argument layouts in the specialized function
- * descriptor, are called <em>variadic argument layouts</em>. For a prototype-less function, the index passed to
+ * the parameter list. The corresponding argument layout (if any), and all following argument layouts in the specialized
+ * function descriptor, are called <em>variadic argument layouts</em>. For a prototype-less function, the index passed to
  * {@link Linker.Option#firstVariadicArg(int)} should always be {@code 0}.
  * <p>
  * The native linker will reject an attempt to link a specialized function descriptor with any variadic argument layouts
@@ -644,8 +644,23 @@ public sealed interface Linker permits AbstractLinker {
             permits LinkerOptions.LinkerOptionImpl {
 
         /**
-         * {@return a linker option used to denote the index of the first variadic argument layout in the
-         *          function descriptor associated with a downcall linkage request}
+         * {@return a linker option used to denote the index indicating the start of the variadic arguments passed to the
+         *          function described by the function descriptor associated with a downcall linkage request}
+         * <p>
+         * The {@code index} value must conform to {@code 0 <= index <= N}, where {@code N} is the number of argument
+         * layouts of the function descriptor used in conjunction with this linker option. When the {@code index} is:
+         * <ul>
+         * <li>{@code 0}, all arguments passed to the function are passed as variadic arguments</li>
+         * <li>{@code N}, none of the arguments passed to the function are passed as variadic arguments</li>
+         * <li>{@code n}, where {@code 0 < m < N}, the arguments {@code m..N} are passed as variadic arguments</li>
+         * </ul>
+         * It is important to always use this linker option when linking a <a href=Linker.html#variadic-funcs>variadic
+         * function</a>, even if no variadic argument is passed (the second case in the list
+         * above), as this might still affect the calling convention on certain platforms.
+         *
+         * @implNote The index value is validated when making a linkage request, which is when the function descriptor
+         *           against which the index is validated is available.
+         *
          * @param index the index of the first variadic argument layout in the function descriptor associated
          *              with a downcall linkage request.
          */


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [7fffdb5e](https://github.com/openjdk/jdk/commit/7fffdb5e60351026c9ee77f438b8fe505d85de4c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jorn Vernee on 28 Jun 2023 and was reviewed by Maurizio Cimadamore.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8310405](https://bugs.openjdk.org/browse/JDK-8310405): Linker.Option.firstVariadicArg should specify which index values are valid (**Enhancement** - P3)
 * [JDK-8310836](https://bugs.openjdk.org/browse/JDK-8310836): Linker.Option.firstVariadicArg should specify which index values are valid (**CSR**) (Withdrawn)

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/78/head:pull/78` \
`$ git checkout pull/78`

Update a local copy of the PR: \
`$ git checkout pull/78` \
`$ git pull https://git.openjdk.org/jdk21.git pull/78/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 78`

View PR using the GUI difftool: \
`$ git pr show -t 78`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/78.diff">https://git.openjdk.org/jdk21/pull/78.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/78#issuecomment-1611832933)