### PR TITLE
8311046: ProblemList gc/z/TestHighUsage.java with Generational ZGC

### DIFF
--- a/test/hotspot/jtreg/ProblemList-generational-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-generational-zgc.txt
@@ -116,4 +116,4 @@ vmTestbase/gc/gctests/MemoryEaterMT/MemoryEaterMT.java        8289582   windows-
 vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded002/TestDescription.java 8298302 generic-all
 vmTestbase/nsk/sysdict/vm/stress/chain/chain007/chain007.java 8298991 linux-x64
 
-gc/z/TestHighUsage.java                                       8308843 windows-x64
+gc/z/TestHighUsage.java                                       8308843 generic-all


### PR DESCRIPTION
Backport of problemlisting
> Problemlist gc/z/TestHighUsage.java for generic-all to reduce noise in the CI pipeline until [JDK-8308843](https://bugs.openjdk.org/browse/JDK-8308843) can be reevaluated.

This pull request contains a backport of commit [2a9e2f61](https://github.com/openjdk/jdk/commit/2a9e2f614f367965cb106ce42d865161e056c386) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311046](https://bugs.openjdk.org/browse/JDK-8311046): ProblemList gc/z/TestHighUsage.java with Generational ZGC (**Sub-task** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/84/head:pull/84` \
`$ git checkout pull/84`

Update a local copy of the PR: \
`$ git checkout pull/84` \
`$ git pull https://git.openjdk.org/jdk21.git pull/84/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 84`

View PR using the GUI difftool: \
`$ git pr show -t 84`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/84.diff">https://git.openjdk.org/jdk21/pull/84.diff</a>

</details>
