### PR TITLE
8308585: AC_REQUIRE: `PLATFORM_EXTRACT_TARGET_AND_BUILD' was expanded before it was required

### DIFF
--- a/make/autoconf/platform.m4
+++ b/make/autoconf/platform.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -660,11 +660,10 @@ AC_DEFUN_ONCE([PLATFORM_SETUP_OPENJDK_BUILD_AND_TARGET],
   PLATFORM_CHECK_DEPRECATION
 ])
 
-AC_DEFUN_ONCE([PLATFORM_CHECK_DEPRECATION],
+AC_DEFUN([PLATFORM_CHECK_DEPRECATION],
 [
   AC_ARG_ENABLE(deprecated-ports, [AS_HELP_STRING([--enable-deprecated-ports@<:@=yes/no@:>@],
        [Suppress the error when configuring for a deprecated port @<:@no@:>@])])
-  AC_REQUIRE([PLATFORM_EXTRACT_TARGET_AND_BUILD])
   if test "x$OPENJDK_TARGET_OS" = xwindows && test "x$OPENJDK_TARGET_CPU" = xx86; then
     if test "x$enable_deprecated_ports" = "xyes"; then
       AC_MSG_WARN([The Windows 32-bit x86 port is deprecated and may be removed in a future release.])

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -463,7 +463,8 @@ var getJibProfilesProfiles = function (input, common, data) {
             target_cpu: "x86",
             build_cpu: "x64",
             dependencies: ["devkit", "gtest"],
-            configure_args: concat(common.configure_args_32bit),
+            configure_args: concat(common.configure_args_32bit,
+                "--enable-deprecated-ports"),
         },
 
         "windows-aarch64": {


### PR DESCRIPTION
This is a clean backport of what was initially a configure warning fix, but turned out to also fix the original intention of JEP 449: deprecating the Windows 32-bit port.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308585](https://bugs.openjdk.org/browse/JDK-8308585): AC_REQUIRE: `PLATFORM_EXTRACT_TARGET_AND_BUILD' was expanded before it was required (**Bug** - P3)


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/85/head:pull/85` \
`$ git checkout pull/85`

Update a local copy of the PR: \
`$ git checkout pull/85` \
`$ git pull https://git.openjdk.org/jdk21.git pull/85/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 85`

View PR using the GUI difftool: \
`$ git pr show -t 85`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/85.diff">https://git.openjdk.org/jdk21/pull/85.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/85#issuecomment-1614412270)