### PR TITLE
8311122: Fix typos in java.base

### DIFF
--- a/src/java.base/share/classes/java/lang/FdLibm.java
+++ b/src/java.base/share/classes/java/lang/FdLibm.java
@@ -1696,7 +1696,7 @@ final class FdLibm {
      *        This formula has one division fewer than the one above; however,
      *        it requires more multiplications and additions. Also x must be
      *        scaled in advance to avoid spurious overflow in evaluating the
-     *        expression 3y*y+x. Hence it is not recommended uless division
+     *        expression 3y*y+x. Hence it is not recommended unless division
      *        is slow. If division is very slow, then one should use the
      *        reciproot algorithm given in section B.
      *
@@ -3156,7 +3156,7 @@ final class FdLibm {
                 return h*StrictMath.exp(Math.abs(x));
             }
 
-            // |x| in [log(maxdouble), overflowthresold]
+            // |x| in [log(maxdouble), overflowthreshold]
             lx = __LO(x);
             if (ix < 0x4086_33CE ||
                 ((ix == 0x4086_33ce) &&
@@ -3166,7 +3166,7 @@ final class FdLibm {
                 return t * w;
             }
 
-            // |x| > overflowthresold, sinh(x) overflow
+            // |x| > overflowthreshold, sinh(x) overflow
             return x * shuge;
         }
     }
@@ -3231,7 +3231,7 @@ final class FdLibm {
                 return 0.5*StrictMath.exp(Math.abs(x));
             }
 
-            // |x| in [log(maxdouble), overflowthresold]
+            // |x| in [log(maxdouble), overflowthreshold]
             lx = __LO(x);
             if (ix<0x4086_33CE ||
                 ((ix == 0x4086_33ce) &&
@@ -3241,7 +3241,7 @@ final class FdLibm {
                 return t*w;
             }
 
-            // |x| > overflowthresold, cosh(x) overflow
+            // |x| > overflowthreshold, cosh(x) overflow
             return huge*huge;
         }
     }

--- a/src/java.base/share/classes/java/lang/Float.java
+++ b/src/java.base/share/classes/java/lang/Float.java
@@ -1162,7 +1162,7 @@ public final class Float extends Number
         }
 
         // No bits set in significand beyond the *first* exponent bit,
-        // not just the sigificand; quantity is added to the exponent
+        // not just the significand; quantity is added to the exponent
         // to implement a carry out from rounding the significand.
         assert (0xf800 & signif_bits) == 0x0;
 

--- a/src/java.base/share/classes/java/lang/ScopedValue.java
+++ b/src/java.base/share/classes/java/lang/ScopedValue.java
@@ -531,7 +531,7 @@ public final class ScopedValue<T> {
 
     /**
      * Creates a new {@code Carrier} with a single mapping of a {@code ScopedValue}
-     * <em>key</em> to a value. The {@code Carrier} can be used to accumlate mappings so
+     * <em>key</em> to a value. The {@code Carrier} can be used to accumulate mappings so
      * that an operation can be executed with all scoped values in the mapping bound to
      * values. The following example runs an operation with {@code k1} bound (or rebound)
      * to {@code v1}, and {@code k2} bound (or rebound) to {@code v2}.

--- a/src/java.base/share/classes/java/lang/invoke/GenerateJLIClassesHelper.java
+++ b/src/java.base/share/classes/java/lang/invoke/GenerateJLIClassesHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ import static java.lang.invoke.LambdaForm.Kind.*;
  * generate classes ahead of time.
  */
 class GenerateJLIClassesHelper {
-    // Map from DirectMethodHandle method type name to index to LambdForms
+    // Map from DirectMethodHandle method type name to index to LambdaForms
     static final Map<String, Integer> DMH_METHOD_TYPE_MAP =
             Map.of(
                     DIRECT_INVOKE_VIRTUAL.methodName,     LF_INVVIRTUAL,

--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -332,7 +332,7 @@ class LambdaForm {
         this.isCompiled = false;
     }
 
-    // root factory pre/post processing and calls simple cosntructor
+    // root factory pre/post processing and calls simple constructor
     private static LambdaForm create(int arity, Name[] names, int result, boolean forceInline, MethodHandle customized, Kind kind) {
         names = names.clone();
         assert(namesOK(arity, names));

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1124,7 +1124,7 @@ abstract class MethodHandleImpl {
          * Method::invoke on a caller-sensitive method will call
          * MethodAccessorImpl::invoke(Object, Object[]) through reflect_invoke_V
          *     target.csm(args)
-         *     NativeMethodAccesssorImpl::invoke(target, args)
+         *     NativeMethodAccessorImpl::invoke(target, args)
          *     MethodAccessImpl::invoke(target, args)
          *     InjectedInvoker::reflect_invoke_V(vamh, target, args);
          *     method::invoke(target, args)
@@ -1683,7 +1683,7 @@ abstract class MethodHandleImpl {
      * @param tloop the return type of the loop.
      * @param targs types of the arguments to be passed to the loop.
      * @param init sanitized array of initializers for loop-local variables.
-     * @param step sanitited array of loop bodies.
+     * @param step sanitized array of loop bodies.
      * @param pred sanitized array of predicates.
      * @param fini sanitized array of loop finalizers.
      *

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -3843,7 +3843,7 @@ return mh1;
 
         /**
          * Perform steps 1 and 2b <a href="MethodHandles.Lookup.html#secmgr">access checks</a>
-         * for ensureInitialzed, findClass or accessClass.
+         * for ensureInitialized, findClass or accessClass.
          */
         void checkSecurityManager(Class<?> refc) {
             if (allowedModes == TRUSTED)  return;

--- a/src/java.base/share/classes/java/lang/reflect/ClassFileFormatVersion.java
+++ b/src/java.base/share/classes/java/lang/reflect/ClassFileFormatVersion.java
@@ -370,7 +370,7 @@ public enum ClassFileFormatVersion {
     public static ClassFileFormatVersion fromMajor(int major) {
         if (major < 45  // RELEASE_0.major()
             || major > latest().major()) {
-            throw new IllegalArgumentException("Out of range major class file vesion "
+            throw new IllegalArgumentException("Out of range major class file version "
                                                + major);
         }
         // RELEASE_0 and RELEASE_1 both have a major version of 45;

--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -1268,7 +1268,7 @@ public class Proxy implements java.io.Serializable {
                     // the method's declaring class is left unvisited.
                     continue;
                 }
-                // visit all superinteraces of one proxy interface to find if
+                // visit all superinterfaces of one proxy interface to find if
                 // this proxy interface inherits the method directly or indirectly
                 visited.add(c);
                 for (Class<?> superIntf : c.getInterfaces()) {

--- a/src/java.base/share/classes/java/text/DigitList.java
+++ b/src/java.base/share/classes/java/text/DigitList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,7 +92,7 @@ final class DigitList implements Cloneable {
      * f is a value 0.1 <= f < 1 arrived at by placing the digits in Digits to
      * the right of the decimal.
      *
-     * DigitList is normalized, so if it is non-zero, figits[0] is non-zero.  We
+     * DigitList is normalized, so if it is non-zero, digits[0] is non-zero.  We
      * don't allow denormalized numbers because our exponent is effectively of
      * unlimited magnitude.  The count value contains the number of significant
      * digits present in digits[].

--- a/src/java.base/share/classes/sun/security/provider/certpath/ResponderId.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/ResponderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -222,7 +222,7 @@ public final class ResponderId {
      *
      * @param obj the object to be compared against
      *
-     * @return true if the specified object is equal to this {@code Responderid}
+     * @return true if the specified object is equal to this {@code ResponderId}
      */
     @Override
     public boolean equals(Object obj) {

--- a/src/java.base/share/classes/sun/security/util/ByteArrays.java
+++ b/src/java.base/share/classes/sun/security/util/ByteArrays.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 package sun.security.util;
 
 /**
- * A time-instance comparison of two byte arrays.
+ * A time-constant comparison of two byte arrays.
  */
 public class ByteArrays {
     // See the MessageDigest.isEqual(byte[] digesta, byte[] digestb)

--- a/src/java.base/share/classes/sun/text/CompactByteArray.java
+++ b/src/java.base/share/classes/sun/text/CompactByteArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -293,7 +293,7 @@ public final class CompactByteArray implements Cloneable {
             if (elementAt((char)i) != other.elementAt((char)i))
                 return false;
         }
-        return true; // we made it through the guantlet.
+        return true; // we made it through the gauntlet.
     }
 
     /**


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [7b3c2dc5](https://github.com/openjdk/jdk/commit/7b3c2dc5f45afc3646ff5cdc0f6efd68e0b70ea5) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Pavel Rappo on 4 Jul 2023 and was reviewed by Joe Darcy, Naoto Sato, Mandy Chung, Iris Clark, Hamlin Li and Sean Mullan.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311122](https://bugs.openjdk.org/browse/JDK-8311122): Fix typos in java.base (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/94/head:pull/94` \
`$ git checkout pull/94`

Update a local copy of the PR: \
`$ git checkout pull/94` \
`$ git pull https://git.openjdk.org/jdk21.git pull/94/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 94`

View PR using the GUI difftool: \
`$ git pr show -t 94`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/94.diff">https://git.openjdk.org/jdk21/pull/94.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/94#issuecomment-1620635872)