### PR TITLE
Backport 45482b4e83458296cf6c93d02bba194de7a51610

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -575,7 +575,7 @@ JvmtiEnv::SetEventNotificationMode(jvmtiEventMode mode, jvmtiEvent event_type, j
   if (event_type == JVMTI_EVENT_CLASS_FILE_LOAD_HOOK && enabled) {
     record_class_file_load_hook_enabled();
   }
-  JvmtiVTMSTransitionDisabler disabler(event_thread);
+  JvmtiVTMSTransitionDisabler disabler;
 
   if (event_thread == nullptr) {
     // Can be called at Agent_OnLoad() time with event_thread == nullptr


### PR DESCRIPTION
Clean backport from mainline jdk repo to jdk21 for the fix of:
  [8303086](https://bugs.openjdk.org/browse/JDK-8303086): SIGSEGV in JavaThread::is_interp_only_mode()

Testing:
 - TBD: mach5 tiers 1-5