### PR TITLE
8311092: Please disable runtime/jni/nativeStack/TestNativeStack.java on armhf

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/nativeStack/TestNativeStack.java
+++ b/test/hotspot/jtreg/runtime/jni/nativeStack/TestNativeStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug  8295974
- * @requires os.family != "windows"
+ * @requires os.family != "windows" & os.arch != "arm"
  * @library /test/lib
  * @summary Generate a JNI Fatal error, or a warning, in a launched VM and check
  *          the native stack is present as expected.


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [0916e6a6](https://github.com/openjdk/jdk/commit/0916e6a603a595e2280765f9159f9be24ada4af6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Vladimir Petko on 3 Jul 2023 and was reviewed by David Holmes.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311092](https://bugs.openjdk.org/browse/JDK-8311092): Please disable runtime/jni/nativeStack/TestNativeStack.java on armhf (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/97/head:pull/97` \
`$ git checkout pull/97`

Update a local copy of the PR: \
`$ git checkout pull/97` \
`$ git pull https://git.openjdk.org/jdk21.git pull/97/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 97`

View PR using the GUI difftool: \
`$ git pr show -t 97`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/97.diff">https://git.openjdk.org/jdk21/pull/97.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/97#issuecomment-1622472198)