### PR TITLE
8311548: AArch64: [ZGC] Many tests fail with "assert(allocates2(pc)) failed: not in CodeBuffer memory" on some CPUs

### DIFF
--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
@@ -39,7 +39,7 @@ enum platform_dependent_constants {
   _initial_stubs_code_size      = 10000,
   _continuation_stubs_code_size =  2000,
   _compiler_stubs_code_size     = 30000 ZGC_ONLY(+10000),
-  _final_stubs_code_size        = 20000 ZGC_ONLY(+60000)
+  _final_stubs_code_size        = 20000 ZGC_ONLY(+100000)
 };
 
 class aarch64 {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [4b1403d0](https://github.com/openjdk/jdk/commit/4b1403d06b99b91ddd89ad6e54669b0595f1f8e5) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Hao Sun on 10 Jul 2023 and was reviewed by Axel Boldt-Christmas, Fei Yang, Kim Barrett and Thomas Schatzl.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311548](https://bugs.openjdk.org/browse/JDK-8311548): AArch64: [ZGC] Many tests fail with "assert(allocates2(pc)) failed: not in CodeBuffer memory" on some CPUs (**Bug** - P2)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/108/head:pull/108` \
`$ git checkout pull/108`

Update a local copy of the PR: \
`$ git checkout pull/108` \
`$ git pull https://git.openjdk.org/jdk21.git pull/108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 108`

View PR using the GUI difftool: \
`$ git pr show -t 108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/108.diff">https://git.openjdk.org/jdk21/pull/108.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/108#issuecomment-1629804127)