### PR TITLE
8311593: Minor doc issue in MemorySegment::copy

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1252,7 +1252,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * {@code srcOffset} through {@code srcOffset + bytes - 1} in the source segment are copied into the destination
      * segment at offset {@code dstOffset} through {@code dstOffset + bytes - 1}.
      * <p>
-     * If the source segment overlaps with this segment, then the copying is performed as if the bytes at
+     * If the source segment overlaps with the destination segment, then the copying is performed as if the bytes at
      * offset {@code srcOffset} through {@code srcOffset + bytes - 1} in the source segment were first copied into a
      * temporary segment with size {@code bytes}, and then the contents of the temporary segment were copied into
      * the destination segment at offset {@code dstOffset} through {@code dstOffset + bytes - 1}.
@@ -1300,7 +1300,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * If the byte order of the two element layouts differ, the bytes corresponding to each element to be copied
      * are swapped accordingly during the copy operation.
      * <p>
-     * If the source segment overlaps with this segment, then the copying is performed as if the bytes at
+     * If the source segment overlaps with the destination segment, then the copying is performed as if the bytes at
      * offset {@code srcOffset} through {@code srcOffset + (elementCount * S) - 1} in the source segment were first copied into a
      * temporary segment with size {@code bytes}, and then the contents of the temporary segment were copied into
      * the destination segment at offset {@code dstOffset} through {@code dstOffset + (elementCount * S) - 1}.


### PR DESCRIPTION
Clean backport of https://git.openjdk.org/jdk/pull/14813
(sorry for filing another one, I realized there was an issue with the JBS issues pointing the wrong way)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311593](https://bugs.openjdk.org/browse/JDK-8311593): Minor doc issue in MemorySegment::copy (**Bug** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/109/head:pull/109` \
`$ git checkout pull/109`

Update a local copy of the PR: \
`$ git checkout pull/109` \
`$ git pull https://git.openjdk.org/jdk21.git pull/109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 109`

View PR using the GUI difftool: \
`$ git pr show -t 109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/109.diff">https://git.openjdk.org/jdk21/pull/109.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/109#issuecomment-1629929619)