### PR TITLE
8311245: JFR: Remove t.printStackTrace() in PeriodicEvents

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/PeriodicEvents.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/PeriodicEvents.java
@@ -96,16 +96,8 @@ public final class PeriodicEvents {
 
     // Only to be called from periodic task thread
     public static long doPeriodic() {
-        try {
-            return runPeriodic(JVM.counterTime());
-        } catch (Throwable t) {
-            t.printStackTrace();
-            throw t;
-        }
-    }
-
-    // Code copied from prior native implementation
-    private static long runPeriodic(long eventTimestamp) {
+        long eventTimestamp = JVM.counterTime();
+        // Code copied from prior native implementation
         long last = lastTimeMillis;
         // The interval for periodic events is typically at least 1 s, so
         // System.currentTimeMillis() is sufficient. JVM.counterTime() lacks


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311245](https://bugs.openjdk.org/browse/JDK-8311245): JFR: Remove t.printStackTrace() in PeriodicEvents (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/110/head:pull/110` \
`$ git checkout pull/110`

Update a local copy of the PR: \
`$ git checkout pull/110` \
`$ git pull https://git.openjdk.org/jdk21.git pull/110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 110`

View PR using the GUI difftool: \
`$ git pr show -t 110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/110.diff">https://git.openjdk.org/jdk21/pull/110.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/110#issuecomment-1630729563)