### PR TITLE
8306785: fix deficient spliterators for Sequenced Collections

### DIFF
--- a/src/java.base/share/classes/java/util/ArrayList.java
+++ b/src/java.base/share/classes/java/util/ArrayList.java
@@ -1509,7 +1509,10 @@ public class ArrayList<E> extends AbstractList<E>
         public Spliterator<E> spliterator() {
             checkForComodification();
 
-            // ArrayListSpliterator not used here due to late-binding
+            // This Spliterator needs to late-bind to the subList, not the outer
+            // ArrayList. Note that it is legal for structural changes to be made
+            // to a subList after spliterator() is called but before any spliterator
+            // operations that would causing binding are performed.
             return new Spliterator<E>() {
                 private int index = offset; // current index, modified on advance/split
                 private int fence = -1; // -1 until used; then one past last index
@@ -1628,9 +1631,7 @@ public class ArrayList<E> extends AbstractList<E>
          * be worthwhile in practice. To carry this out, we (1) lazily
          * initialize fence and expectedModCount until the latest
          * point that we need to commit to the state we are checking
-         * against; thus improving precision.  (This doesn't apply to
-         * SubLists, that create spliterators with current non-lazy
-         * values).  (2) We perform only a single
+         * against; thus improving precision. (2) We perform only a single
          * ConcurrentModificationException check at the end of forEach
          * (the most performance-sensitive method). When using forEach
          * (as opposed to iterators), we can normally only detect

--- a/src/java.base/share/classes/java/util/ReverseOrderDequeView.java
+++ b/src/java.base/share/classes/java/util/ReverseOrderDequeView.java
@@ -61,7 +61,7 @@ class ReverseOrderDequeView<E> implements Deque<E> {
     }
 
     public Spliterator<E> spliterator() {
-        return Spliterators.spliteratorUnknownSize(base.descendingIterator(), 0);
+        return Spliterators.spliterator(this, Spliterator.ORDERED);
     }
 
     // ========== Collection ==========

--- a/src/java.base/share/classes/java/util/ReverseOrderListView.java
+++ b/src/java.base/share/classes/java/util/ReverseOrderListView.java
@@ -151,8 +151,7 @@ class ReverseOrderListView<E> implements List<E> {
     }
 
     public Spliterator<E> spliterator() {
-        // TODO can probably improve this
-        return Spliterators.spliteratorUnknownSize(new DescendingIterator(), 0);
+        return Spliterators.spliterator(this, Spliterator.ORDERED);
     }
 
     // ========== Collection ==========

--- a/src/java.base/share/classes/java/util/ReverseOrderSortedSetView.java
+++ b/src/java.base/share/classes/java/util/ReverseOrderSortedSetView.java
@@ -111,7 +111,7 @@ class ReverseOrderSortedSetView<E> implements SortedSet<E> {
     }
 
     public Spliterator<E> spliterator() {
-        return Spliterators.spliteratorUnknownSize(descendingIterator(base), 0);
+        return Spliterators.spliterator(this, Spliterator.ORDERED);
     }
 
     // ========== Collection ==========

--- a/src/java.base/share/classes/java/util/Spliterators.java
+++ b/src/java.base/share/classes/java/util/Spliterators.java
@@ -948,10 +948,12 @@ public final class Spliterators {
         private int index;        // current index, modified on advance/split
         private final int fence;  // one past last index
         private final int characteristics;
-        private long estimatedSize; // estimated size, to help to split evenly
+        private long estimatedSize; // if >= 0, the estimated size, to help to split evenly
+                                    // if -1, exact size is known to be fence - index
 
         /**
          * Creates a spliterator covering all of the given array.
+         * Its size is known exactly and it is SIZED and SUBSIZED.
          * @param array the array, assumed to be unmodified during use
          * @param additionalCharacteristics Additional spliterator characteristics
          * of this spliterator's source or elements beyond {@code SIZED} and
@@ -962,7 +964,8 @@ public final class Spliterators {
         }
 
         /**
-         * Creates a spliterator covering the given array and range
+         * Creates a spliterator covering the given array and range.
+         * Its size is known exactly and it is SIZED and SUBSIZED.
          * @param array the array, assumed to be unmodified during use
          * @param origin the least index (inclusive) to cover
          * @param fence one past the greatest index to cover
@@ -978,6 +981,18 @@ public final class Spliterators {
             this.estimatedSize = -1;
         }
 
+        /**
+         * Creates a spliterator covering the given array and range but that is
+         * not SIZED or SUBSIZED. This case occurs as a result of splitting another
+         * spliterator that is not sized, so it's inappropriate for one of its
+         * sub-spliterators to be sized.
+         * @param array the array, assumed to be unmodified during use
+         * @param origin the least index (inclusive) to cover
+         * @param fence one past the greatest index to cover
+         * @param characteristics characteristics of this spliterator's source; {@code SIZED} and
+         *        {@code SUBSIZED} are removed if present
+         * @param estimatedSize the size estimate; should always be nonnegative
+         */
         private ArraySpliterator(Object[] array, int origin, int fence, int characteristics, long estimatedSize) {
             this.array = array;
             this.index = origin;

--- a/src/java.base/share/classes/java/util/concurrent/CopyOnWriteArrayList.java
+++ b/src/java.base/share/classes/java/util/concurrent/CopyOnWriteArrayList.java
@@ -1822,8 +1822,7 @@ public class CopyOnWriteArrayList<E>
         }
 
         public Spliterator<E> spliterator() {
-            // TODO can probably improve this
-            return Spliterators.spliteratorUnknownSize(new DescendingIterator(), 0);
+            return Spliterators.spliterator(this, Spliterator.ORDERED);
         }
 
         // ========== Collection ==========


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [743e8b8e](https://github.com/openjdk/jdk/commit/743e8b8e0a9fe032a0dd652a4fef1f761af66595) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Stuart Marks on 12 Jul 2023 and was reviewed by Paul Sandoz.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306785](https://bugs.openjdk.org/browse/JDK-8306785): fix deficient spliterators for Sequenced Collections (**Bug** - P3)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/118/head:pull/118` \
`$ git checkout pull/118`

Update a local copy of the PR: \
`$ git checkout pull/118` \
`$ git pull https://git.openjdk.org/jdk21.git pull/118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 118`

View PR using the GUI difftool: \
`$ git pr show -t 118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/118.diff">https://git.openjdk.org/jdk21/pull/118.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/118#issuecomment-1633595348)