### PR TITLE
8311645: Memory leak in jspawnhelper spawnChild after JDK-8307990

### DIFF
--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -562,6 +562,7 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
 
     /* write the two structs and the data buffer */
     if (writeFully(c->childenv[1], (char *)&magic, sizeof(magic)) != sizeof(magic)) { // magic number first
+        free(buf);
         return -1;
     }
 #ifdef DEBUG
@@ -570,6 +571,7 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     if (writeFully(c->childenv[1], (char *)c, sizeof(*c)) != sizeof(*c) ||
         writeFully(c->childenv[1], (char *)&sp, sizeof(sp)) != sizeof(sp) ||
         writeFully(c->childenv[1], buf, bufsize) != bufsize) {
+        free(buf);
         return -1;
     }
     /* We're done. Let jspwanhelper know he can't expect any more data from us. */


### PR DESCRIPTION
Clean backport. Fixes the regression introduced in JDK 21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311645](https://bugs.openjdk.org/browse/JDK-8311645): Memory leak in jspawnhelper spawnChild after JDK-8307990 (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/120/head:pull/120` \
`$ git checkout pull/120`

Update a local copy of the PR: \
`$ git checkout pull/120` \
`$ git pull https://git.openjdk.org/jdk21.git pull/120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 120`

View PR using the GUI difftool: \
`$ git pr show -t 120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/120.diff">https://git.openjdk.org/jdk21/pull/120.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/120#issuecomment-1633815733)