### PR TITLE
8311647: Memory leak in Java_jdk_internal_org_jline_terminal_impl_jna_linux_CLibraryImpl_ttyname_1r

### DIFF
--- a/src/jdk.internal.le/linux/native/lible/CLibrary.cpp
+++ b/src/jdk.internal.le/linux/native/lible/CLibrary.cpp
@@ -187,6 +187,7 @@ JNIEXPORT void JNICALL Java_jdk_internal_org_jline_terminal_impl_jna_linux_CLibr
     int error = ttyname_r(fd, data, len);
 
     if (error != 0) {
+        delete[] data;
         throw_errno(env);
         return ;
     }

--- a/src/jdk.internal.le/macosx/native/lible/CLibrary.cpp
+++ b/src/jdk.internal.le/macosx/native/lible/CLibrary.cpp
@@ -191,6 +191,7 @@ JNIEXPORT void JNICALL Java_jdk_internal_org_jline_terminal_impl_jna_osx_CLibrar
     int error = ttyname_r(fd, data, len);
 
     if (error != 0) {
+        delete[] data;
         throw_errno(env);
         return ;
     }


### PR DESCRIPTION
Clean backport to fix a memory leak introduced in JDK 21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311647](https://bugs.openjdk.org/browse/JDK-8311647): Memory leak in Java_jdk_internal_org_jline_terminal_impl_jna_linux_CLibraryImpl_ttyname_1r (**Bug** - P3)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/126/head:pull/126` \
`$ git checkout pull/126`

Update a local copy of the PR: \
`$ git checkout pull/126` \
`$ git pull https://git.openjdk.org/jdk21.git pull/126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 126`

View PR using the GUI difftool: \
`$ git pr show -t 126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/126.diff">https://git.openjdk.org/jdk21/pull/126.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/126#issuecomment-1635579362)