### PR TITLE
8311038: Incorrect exhaustivity computation

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -844,6 +844,8 @@ public class Flow {
                     for (Type sup : types.directSupertypes(bpOne.type)) {
                         ClassSymbol clazz = (ClassSymbol) sup.tsym;
 
+                        clazz.complete();
+
                         if (clazz.isSealed() && clazz.isAbstract() &&
                             //if a binding pattern for clazz already exists, no need to analyze it again:
                             !existingBindings.contains(clazz)) {
@@ -891,7 +893,9 @@ public class Flow {
                                     }
 
                                     if (reduces) {
-                                        bindings.append(pdOther);
+                                        if (!types.isSubtype(types.erasure(clazz.type), types.erasure(bpOther.type))) {
+                                            bindings.append(pdOther);
+                                        }
                                     }
                                 }
                             }
@@ -925,6 +929,8 @@ public class Flow {
                 ClassSymbol current = permittedSubtypesClosure.head;
 
                 permittedSubtypesClosure = permittedSubtypesClosure.tail;
+
+                current.complete();
 
                 if (current.isSealed() && current.isAbstract()) {
                     for (Symbol sym : current.permitted) {

--- a/test/langtools/tools/javac/patterns/Exhaustiveness.java
+++ b/test/langtools/tools/javac/patterns/Exhaustiveness.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8262891 8268871 8274363 8281100 8294670
+ * @bug 8262891 8268871 8274363 8281100 8294670 8311038
  * @summary Check exhaustiveness of switches over sealed types.
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -1944,6 +1944,26 @@ public class Exhaustiveness extends TestRunner {
                                System.out.println("C2");
                        }
                    }
+               }
+               """);
+    }
+
+    @Test //JDK-8311038
+    public void testReducesTooMuch(Path base) throws Exception {
+        doTest(base,
+               new String[0],
+               """
+               package test;
+               public class Test {
+                   void test(Rec r) {
+                       switch (r) {
+                           case Rec(String s) ->
+                               System.out.println("I2" + s.toString());
+                           case Rec(Object o) ->
+                               System.out.println("I2");
+                       }
+                   }
+                   record Rec(Object o) {}
                }
                """);
     }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [bbb7ce51](https://github.com/openjdk/jdk/commit/bbb7ce5137cd3e8365552b42610e19b7ebe43ba1) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jan Lahoda on 14 Jul 2023 and was reviewed by Vicente Romero.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311038](https://bugs.openjdk.org/browse/JDK-8311038): Incorrect exhaustivity computation (**Bug** - P2)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/127/head:pull/127` \
`$ git checkout pull/127`

Update a local copy of the PR: \
`$ git checkout pull/127` \
`$ git pull https://git.openjdk.org/jdk21.git pull/127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 127`

View PR using the GUI difftool: \
`$ git pr show -t 127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/127.diff">https://git.openjdk.org/jdk21/pull/127.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/127#issuecomment-1635624962)