### PR TITLE
8311825: Duplicate qualified enum constants not detected

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1734,6 +1734,8 @@ public class Attr extends JCTree.Visitor {
                                     Symbol enumSym = TreeInfo.symbol(expr);
                                     if (enumSym == null || !enumSym.isEnum() || enumSym.kind != VAR) {
                                         log.error(expr.pos(), Errors.EnumLabelMustBeEnumConstant);
+                                    } else if (!constants.add(enumSym)) {
+                                        log.error(label.pos(), Errors.DuplicateCaseLabel);
                                     }
                                 } else {
                                     log.error(expr.pos(), Errors.EnumLabelMustBeUnqualifiedEnum);
@@ -1765,6 +1767,8 @@ public class Attr extends JCTree.Visitor {
                                                   (stringSwitch ? Errors.StringConstReq
                                                                 : intSwitch ? Errors.ConstExprReq
                                                                             : Errors.PatternOrEnumReq));
+                                    } else if (!constants.add(s)) {
+                                        log.error(label.pos(), Errors.DuplicateCaseLabel);
                                     }
                                 } else if (!stringSwitch && !intSwitch) {
                                     log.error(label.pos(), Errors.ConstantLabelNotCompatible(pattype, seltype));

--- a/test/langtools/tools/javac/switchextra/EnumSwitchQualifiedErrors.java
+++ b/test/langtools/tools/javac/switchextra/EnumSwitchQualifiedErrors.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8300543 8309336
+ * @bug 8300543 8309336 8311825
  * @summary Check switches work correctly with qualified enum constants
  * @compile/fail/ref=EnumSwitchQualifiedErrors.out -XDrawDiagnostics EnumSwitchQualifiedErrors.java
 */
@@ -66,6 +66,30 @@ public class EnumSwitchQualifiedErrors {
             case (E1) null -> 1;
             case E1 -> 1;
             default -> {}
+        };
+    }
+
+    int testQualifiedDuplicate1(Object o) {
+        return switch(o) {
+            case E1.A -> 1;
+            case E1.A -> 2;
+            default -> -1;
+        };
+    }
+
+    int testQualifiedDuplicate2(E1 e) {
+        return switch(e) {
+            case A -> 1;
+            case E1.A -> 2;
+            default -> -1;
+        };
+    }
+
+    int testQualifiedDuplicate3(E1 e) {
+        return switch(e) {
+            case E1.A -> 1;
+            case A -> 2;
+            default -> -1;
         };
     }
 

--- a/test/langtools/tools/javac/switchextra/EnumSwitchQualifiedErrors.out
+++ b/test/langtools/tools/javac/switchextra/EnumSwitchQualifiedErrors.out
@@ -8,4 +8,7 @@ EnumSwitchQualifiedErrors.java:58:18: compiler.err.enum.label.must.be.enum.const
 EnumSwitchQualifiedErrors.java:65:18: compiler.err.pattern.or.enum.req
 EnumSwitchQualifiedErrors.java:66:18: compiler.err.pattern.or.enum.req
 EnumSwitchQualifiedErrors.java:67:18: compiler.err.pattern.expected
-10 errors
+EnumSwitchQualifiedErrors.java:75:18: compiler.err.duplicate.case.label
+EnumSwitchQualifiedErrors.java:83:18: compiler.err.duplicate.case.label
+EnumSwitchQualifiedErrors.java:91:18: compiler.err.duplicate.case.label
+13 errors


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d1fa1a86](https://github.com/openjdk/jdk/commit/d1fa1a868636dc15e96d1b4bf4acf28257c9551f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jan Lahoda on 14 Jul 2023 and was reviewed by Vicente Romero.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311825](https://bugs.openjdk.org/browse/JDK-8311825): Duplicate qualified enum constants not detected (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/128/head:pull/128` \
`$ git checkout pull/128`

Update a local copy of the PR: \
`$ git checkout pull/128` \
`$ git pull https://git.openjdk.org/jdk21.git pull/128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 128`

View PR using the GUI difftool: \
`$ git pr show -t 128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/128.diff">https://git.openjdk.org/jdk21/pull/128.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/128#issuecomment-1635627331)