### PR TITLE
8312093: Incorrect javadoc comment text

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
@@ -1546,7 +1546,10 @@ public class JavaTokenizer extends UnicodeReader {
                     return;
                 }
 
-                skip('*');
+                if (skip('*') != 0 && is('/')) {
+                    return ;
+                }
+
                 skipWhitespace();
 
                 if (isEOLN()) {


### PR DESCRIPTION
A backport of:
https://github.com/openjdk/jdk/pull/14890

that has been previously pushed into the JDK mainline. Conflicts in tests were manually resolved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312093](https://bugs.openjdk.org/browse/JDK-8312093): Incorrect javadoc comment text (**Bug** - P3)


### Reviewers
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/132/head:pull/132` \
`$ git checkout pull/132`

Update a local copy of the PR: \
`$ git checkout pull/132` \
`$ git pull https://git.openjdk.org/jdk21.git pull/132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 132`

View PR using the GUI difftool: \
`$ git pr show -t 132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/132.diff">https://git.openjdk.org/jdk21/pull/132.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/132#issuecomment-1637721844)