### PR TITLE
8312189: ProblemList serviceability/jvmti/vthread/VThreadTLSTest/VThreadTLSTest.java#id1

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -119,6 +119,7 @@ serviceability/sa/TestRevPtrsForInvokeDynamic.java 8241235 generic-all
 
 serviceability/jvmti/ModuleAwareAgents/ThreadStart/MAAThreadStart.java 8225354 windows-all
 serviceability/jvmti/vthread/GetSetLocalTest/GetSetLocalTest.java 8286836 generic-all
+serviceability/jvmti/vthread/VThreadTLSTest/VThreadTLSTest.java#id1 8300051 generic-all
 serviceability/dcmd/gc/RunFinalizationTest.java 8227120 linux-all,windows-x64
 
 serviceability/sa/ClhsdbCDSCore.java 8294316,8267433 macosx-x64


### PR DESCRIPTION
This is a clean 21 backport of a trivial sub-task:
  [8312189](https://bugs.openjdk.org/browse/JDK-8312189): ProblemList serviceability/jvmti/vthread/VThreadTLSTest/VThreadTLSTest.java#id1

It has a dependency on the 21 backport of:
[8311556](https://bugs.openjdk.org/browse/JDK-8311556): GetThreadLocalStorage not working for vthreads mounted during JVMTI attach
which is already on review and needs to be back ported first: [https://github.com/openjdk/jdk21/pull/117](https://github.com/openjdk/jdk21/pull/117)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312189](https://bugs.openjdk.org/browse/JDK-8312189): ProblemList serviceability/jvmti/vthread/VThreadTLSTest/VThreadTLSTest.java#id1 (**Sub-task** - P4)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/137/head:pull/137` \
`$ git checkout pull/137`

Update a local copy of the PR: \
`$ git checkout pull/137` \
`$ git pull https://git.openjdk.org/jdk21.git pull/137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 137`

View PR using the GUI difftool: \
`$ git pr show -t 137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/137.diff">https://git.openjdk.org/jdk21/pull/137.diff</a>

</details>
