### PR TITLE
8311815: Incorrect exhaustivity computation

### DIFF
--- a/test/langtools/tools/javac/patterns/Exhaustiveness.java
+++ b/test/langtools/tools/javac/patterns/Exhaustiveness.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8262891 8268871 8274363 8281100 8294670 8311038
+ * @bug 8262891 8268871 8274363 8281100 8294670 8311038 8311815
  * @summary Check exhaustiveness of switches over sealed types.
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -1540,7 +1540,7 @@ public class Exhaustiveness extends TestRunner {
                "1 error");
     }
 
-    private static final int NESTING_CONSTANT = 5;
+    private static final int NESTING_CONSTANT = 4;
 
     Set<String> createDeeplyNestedVariants() {
         Set<String> variants = new HashSet<>();
@@ -1964,6 +1964,34 @@ public class Exhaustiveness extends TestRunner {
                        }
                    }
                    record Rec(Object o) {}
+               }
+               """);
+    }
+
+    @Test //JDK-8311815:
+    public void testAmbiguousRecordUsage(Path base) throws Exception {
+        doTest(base,
+               new String[0],
+               """
+               package test;
+               public class Test {
+                 record Pair(I i1, I i2) {}
+                 sealed interface I {}
+                 record C() implements I {}
+                 record D() implements I {}
+
+                 void exhaustinvenessWithInterface(Pair pairI) {
+                   switch (pairI) {
+                     case Pair(D fst, C snd) -> {
+                     }
+                     case Pair(C fst, C snd) -> {
+                     }
+                     case Pair(C fst, I snd) -> {
+                     }
+                     case Pair(D fst, D snd) -> {
+                     }
+                   }
+                 }
                }
                """);
     }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [a4412166](https://github.com/openjdk/jdk/commit/a4412166ec8526db5e5e8e1ca324f86124055b30) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jan Lahoda on 17 Jul 2023 and was reviewed by Vicente Romero.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311815](https://bugs.openjdk.org/browse/JDK-8311815): Incorrect exhaustivity computation (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/138/head:pull/138` \
`$ git checkout pull/138`

Update a local copy of the PR: \
`$ git checkout pull/138` \
`$ git pull https://git.openjdk.org/jdk21.git pull/138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 138`

View PR using the GUI difftool: \
`$ git pr show -t 138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/138.diff">https://git.openjdk.org/jdk21/pull/138.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/138#issuecomment-1640744718)