### PR TITLE
8313241: Temporarily disable "malformed control flow" assert to reduce noise

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3992,7 +3992,6 @@ bool Compile::final_graph_reshaping() {
 
       // Recheck with a better notion of 'required_outcnt'
       if (n->outcnt() != required_outcnt) {
-        DEBUG_ONLY( n->dump_bfs(1, 0, "-"); );
         record_method_not_compilable("malformed control flow");
         return true;            // Not all targets reachable!
       }

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3993,7 +3993,6 @@ bool Compile::final_graph_reshaping() {
       // Recheck with a better notion of 'required_outcnt'
       if (n->outcnt() != required_outcnt) {
         DEBUG_ONLY( n->dump_bfs(1, 0, "-"); );
-        assert(false, "malformed control flow");
         record_method_not_compilable("malformed control flow");
         return true;            // Not all targets reachable!
       }

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -709,7 +709,6 @@ sun/util/locale/provider/CalendarDataRegression.java            8268379 macosx-x
 java/util/concurrent/forkjoin/AsyncShutdownNow.java             8286352 linux-all,windows-x64
 java/util/concurrent/ExecutorService/CloseTest.java             8288899 macosx-aarch64
 java/util/concurrent/SynchronousQueue/Fairness.java             8300663 generic-x64
-java/util/concurrent/tck/JSR166TestCase.java                    8312980 generic-x64,linux-aarch64
 
 ############################################################################
 


### PR DESCRIPTION
[JDK-8303951](https://bugs.openjdk.org/browse/JDK-8303951) added asserts before several C2 compilation bailouts that we were never able to trigger in our testing. The "malformed control flow" assert now triggers regularly (see [JDK-8308392](https://bugs.openjdk.org/browse/JDK-8308392) and [JDK-8312980](https://bugs.openjdk.org/browse/JDK-8312980)). Let's disable it in JDK 21 to reduce the noise in the CI.

I also reverted the problem listing done by [JDK-8313208](https://bugs.openjdk.org/browse/JDK-8313208) because, as @AlanBateman noted in https://github.com/openjdk/jdk21/pull/145, it's too invasive.

Approval is pending.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313241](https://bugs.openjdk.org/browse/JDK-8313241): Temporarily disable "malformed control flow" assert to reduce noise (**Bug** - P2)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [3377f7c0](https://git.openjdk.org/jdk21/pull/146/files/3377f7c019c100a04391254281fc20bdbe665fa7)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/146/head:pull/146` \
`$ git checkout pull/146`

Update a local copy of the PR: \
`$ git checkout pull/146` \
`$ git pull https://git.openjdk.org/jdk21.git pull/146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 146`

View PR using the GUI difftool: \
`$ git pr show -t 146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/146.diff">https://git.openjdk.org/jdk21/pull/146.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/146#issuecomment-1653113980)