### PR TITLE
8313250: Exclude java/foreign/TestByteBuffer.java on AIX

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -788,3 +788,8 @@ java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter.java 8254841 macos
 java/awt/Focus/AppletInitialFocusTest/AppletInitialFocusTest1.java 8256289 windows-x64
 java/awt/FullScreen/TranslucentWindow/TranslucentWindow.java 8258103 linux-all
 java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java 8016266 linux-x64
+
+############################################################################
+# java/foreign
+
+java/foreign/TestByteBuffer.java 8309475 aix-ppc64


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8313250](https://bugs.openjdk.org/browse/JDK-8313250), commit [c05ba48b](https://github.com/openjdk/jdk/commit/c05ba48b60816db0165a6d3ff534fbbb18433cd4) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

It's only a test exclusion for AIX, suitable for RDP2.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313250](https://bugs.openjdk.org/browse/JDK-8313250): Exclude java/foreign/TestByteBuffer.java on AIX (**Sub-task** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/148/head:pull/148` \
`$ git checkout pull/148`

Update a local copy of the PR: \
`$ git checkout pull/148` \
`$ git pull https://git.openjdk.org/jdk21.git pull/148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 148`

View PR using the GUI difftool: \
`$ git pr show -t 148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/148.diff">https://git.openjdk.org/jdk21/pull/148.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/148#issuecomment-1653935358)