### PR TITLE
8313260: JDK21: ProblemList java/lang/ScopedValue/StressStackOverflow.java on linux-x86

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -480,7 +480,7 @@ java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-x64
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
 
-java/lang/ScopedValue/StressStackOverflow.java                  8303498 linux-s390x
+java/lang/ScopedValue/StressStackOverflow.java                  8303498,8308609 linux-s390x,linux-x86
 
 ############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -480,7 +480,7 @@ java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-x64
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
 
-java/lang/ScopedValue/StressStackOverflow.java                  8303498,8308609 linux-s390x,linux-x86
+java/lang/ScopedValue/StressStackOverflow.java                  8303498,8308609 linux-s390x,linux-i586
 
 ############################################################################
 


### PR DESCRIPTION
This patch adds the  java/lang/ScopedValue/StressStackOverflow.java to the problem list for linux-x86 where it intermittently fails on a GA, ex: https://github.com/openjdk/jdk21/pull/148

This is only for JDK 21, test passes on JDK 22.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313260](https://bugs.openjdk.org/browse/JDK-8313260): JDK21: ProblemList java/lang/ScopedValue/StressStackOverflow.java on linux-x86 (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/149/head:pull/149` \
`$ git checkout pull/149`

Update a local copy of the PR: \
`$ git checkout pull/149` \
`$ git pull https://git.openjdk.org/jdk21.git pull/149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 149`

View PR using the GUI difftool: \
`$ git pr show -t 149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/149.diff">https://git.openjdk.org/jdk21/pull/149.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/149#issuecomment-1655067046)