### PR TITLE
8300937: Update nroff pages in JDK 21 before RC

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAVA" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JAVA" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -530,26 +530,27 @@ The value \[dq]disabled\[dq] disables finalization, so that no
 finalizers are invoked.
 .TP
 \f[V]--module-path\f[R] \f[I]modulepath\f[R]... or \f[V]-p\f[R] \f[I]modulepath\f[R]
-Specifies where to find application modules with a list of path elements.
-The elements of a module path can be a file path to a module or a directory
-containing modules. Each module is either a modular JAR or an
-exploded-module directory.
+Specifies where to find application modules with a list of path
+elements.
+The elements of a module path can be a file path to a module or a
+directory containing modules.
+Each module is either a modular JAR or an exploded-module directory.
 .RS
 .PP
-On Windows, semicolons (\f[V];\f[R]) separate path elements in this list;
-on other platforms it is a colon (\f[V]:\f[R]).
+On Windows, semicolons (\f[V];\f[R]) separate path elements in this
+list; on other platforms it is a colon (\f[V]:\f[R]).
 .RE
 .TP
 \f[V]--upgrade-module-path\f[R] \f[I]modulepath\f[R]...
-Specifies where to find module replacements of upgradeable modules in the
-runtime image with a list of path elements.
-The elements of a module path can be a file path to a module or a directory
-containing modules. Each module is either a modular JAR or an
-exploded-module directory.
+Specifies where to find module replacements of upgradeable modules in
+the runtime image with a list of path elements.
+The elements of a module path can be a file path to a module or a
+directory containing modules.
+Each module is either a modular JAR or an exploded-module directory.
 .RS
 .PP
-On Windows, semicolons (\f[V];\f[R]) separate path elements in this list;
-on other platforms it is a colon (\f[V]:\f[R]).
+On Windows, semicolons (\f[V];\f[R]) separate path elements in this
+list; on other platforms it is a colon (\f[V]:\f[R]).
 .RE
 .TP
 \f[V]--add-modules\f[R] \f[I]module\f[R][\f[V],\f[R]\f[I]module\f[R]...]
@@ -1305,6 +1306,7 @@ By default this option is disabled.
 .TP
 \f[V]-XX:FlightRecorderOptions=\f[R]\f[I]parameter\f[R]\f[V]=\f[R]\f[I]value\f[R] (or) \f[V]-XX:FlightRecorderOptions:\f[R]\f[I]parameter\f[R]\f[V]=\f[R]\f[I]value\f[R]
 Sets the parameters that control the behavior of JFR.
+Multiple parameters can be specified by separating them with a comma.
 .RS
 .PP
 The following list contains the available JFR
@@ -1370,9 +1372,6 @@ By default, the local buffer size is set to 8 kilobytes, with a minimum
 value of 4 kilobytes.
 Overriding this parameter could reduce performance and is not
 recommended.
-.PP
-You can specify values for multiple parameters by separating them with a
-comma.
 .RE
 .TP
 \f[V]-XX:LargePageSizeInBytes=\f[R]\f[I]size\f[R]
@@ -1659,6 +1658,9 @@ written when the recording is stopped, for example:
 \f[V]/home/user/recordings/recording.jfr\f[R]
 .IP \[bu] 2
 \f[V]c:\[rs]recordings\[rs]recording.jfr\f[R]
+.PP
+If %p and/or %t is specified in the filename, it expands to the
+JVM\[aq]s PID and the current timestamp, respectively.
 .RE
 .TP
 \f[V]name=\f[R]\f[I]identifier\f[R]

--- a/src/java.base/share/man/keytool.1
+++ b/src/java.base/share/man/keytool.1
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "KEYTOOL" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "KEYTOOL" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -447,7 +447,7 @@ single-element certificate chain.
 When the \f[V]-signer\f[R] option is specified, a new certificate is
 generated and signed by the designated signer and stored as a
 multiple-element certificate chain (containing the generated certificate
-itself, and the signer?s certificate chain).
+itself, and the signer\[aq]s certificate chain).
 The certificate chain and private key are stored in a new keystore entry
 that is identified by its alias.
 .PP
@@ -467,8 +467,8 @@ specified.
 The \f[V]-signer\f[R] value specifies the alias of a
 \f[V]PrivateKeyEntry\f[R] for the signer that already exists in the
 keystore.
-This option is used to sign the certificate with the signer?s private
-key.
+This option is used to sign the certificate with the signer\[aq]s
+private key.
 This is especially useful for key agreement algorithms (i.e.
 the \f[V]-keyalg\f[R] value is \f[V]XDH\f[R], \f[V]X25519\f[R],
 \f[V]X448\f[R], or \f[V]DH\f[R]) as these keys cannot be used for
@@ -476,7 +476,7 @@ digital signatures, and therefore a self-signed certificate cannot be
 created.
 .PP
 The \f[V]-signerkeypass\f[R] value specifies the password of the
-signer?s private key.
+signer\[aq]s private key.
 It can be specified if the private key of the signer entry is protected
 by a password different from the store password.
 .PP

--- a/src/java.rmi/share/man/rmiregistry.1
+++ b/src/java.rmi/share/man/rmiregistry.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "RMIREGISTRY" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "RMIREGISTRY" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/java.scripting/share/man/jrunscript.1
+++ b/src/java.scripting/share/man/jrunscript.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JRUNSCRIPT" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JRUNSCRIPT" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.compiler/share/man/javac.1
+++ b/src/jdk.compiler/share/man/javac.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAVAC" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JAVAC" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -413,12 +413,14 @@ generated class file so that the method
 \f[V]java.lang.reflect.Executable.getParameters\f[R] from the Reflection
 API can retrieve them.
 .TP
-\f[V]-proc:\f[R][\f[V]none\f[R], \f[V]only\f[R]]
+\f[V]-proc:\f[R][\f[V]none\f[R], \f[V]only\f[R], \f[V]full\f[R]]
 Controls whether annotation processing and compilation are done.
 \f[V]-proc:none\f[R] means that compilation takes place without
 annotation processing.
 \f[V]-proc:only\f[R] means that only annotation processing is done,
 without any subsequent compilation.
+If this option is not used, or \f[V]-proc:full\f[R] is specified,
+annotation processing and compilation are done.
 .TP
 \f[V]-processor\f[R] \f[I]class1\f[R][\f[V],\f[R]\f[I]class2\f[R]\f[V],\f[R]\f[I]class3\f[R]...]
 Names of the annotation processors to run.
@@ -736,7 +738,8 @@ constructors in public and protected classes in exported packages.
 \f[V]options\f[R]: Warns about the issues relating to use of command
 line options.
 .IP \[bu] 2
-\f[V]output-file-clash\f[R]: Warns if any output file is overwritten during compilation.
+\f[V]output-file-clash\f[R]: Warns if any output file is overwritten
+during compilation.
 This can occur, for example, on case-insensitive filesystems.
 .IP \[bu] 2
 \f[V]overloads\f[R]: Warns about the issues related to method overloads.
@@ -779,8 +782,8 @@ instances of value-based classes.
 \f[V]text-blocks\f[R]: Warns about inconsistent white space characters
 in text block indentation.
 .IP \[bu] 2
-\f[V]this-escape\f[R]: Warns about constructors leaking
-\f[V]this\f[R] prior to subclass initialization.
+\f[V]this-escape\f[R]: Warns about constructors leaking \f[V]this\f[R]
+prior to subclass initialization.
 .IP \[bu] 2
 \f[V]try\f[R]: Warns about the issues relating to the use of try blocks
 (that is, try-with-resources).
@@ -2219,7 +2222,7 @@ Alternately, you can remove the \f[V]static\f[R] keyword from the
 declaration of the method \f[V]m1\f[R].
 .RE
 .TP
-\f[V]this\-escape\f[R]
+\f[V]this-escape\f[R]
 Warns about constructors leaking \f[V]this\f[R] prior to subclass
 initialization.
 For example, this class:
@@ -2239,24 +2242,24 @@ generates the following warning:
 .IP
 .nf
 \f[CB]
-MyClass.java:3: warning: [this-escape] possible 'this' escape
+MyClass.java:3: warning: [this-escape] possible \[aq]this\[aq] escape
                          before subclass is fully initialized
     System.out.println(this.hashCode());
-                                    ^
+                                    \[ha]
 \f[R]
 .fi
 .PP
-A 'this' escape warning is generated when a constructor does something
-that might result in a subclass method being invoked before the
-constructor returns.
+A \[aq]this\[aq] escape warning is generated when a constructor does
+something that might result in a subclass method being invoked before
+the constructor returns.
 In such cases the subclass method would be operating on an incompletely
 initialized instance.
 In the above example, a subclass of \f[V]MyClass\f[R] that overrides
 \f[V]hashCode()\f[R] to incorporate its own fields would likely produce
 an incorrect result when invoked as shown.
 .PP
-Warnings are only generated if a subclass could exist that is outside
-of the current module (or package, if no module) being compiled.
+Warnings are only generated if a subclass could exist that is outside of
+the current module (or package, if no module) being compiled.
 So, for example, constructors in final and non-public classes do not
 generate warnings.
 .RE

--- a/src/jdk.compiler/share/man/serialver.1
+++ b/src/jdk.compiler/share/man/serialver.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "SERIALVER" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "SERIALVER" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.hotspot.agent/share/man/jhsdb.1
+++ b/src/jdk.hotspot.agent/share/man/jhsdb.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JHSDB" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JHSDB" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.httpserver/share/man/jwebserver.1
+++ b/src/jdk.httpserver/share/man/jwebserver.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JWEBSERVER" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JWEBSERVER" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jartool/share/man/jar.1
+++ b/src/jdk.jartool/share/man/jar.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAR" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JAR" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jartool/share/man/jarsigner.1
+++ b/src/jdk.jartool/share/man/jarsigner.1
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JARSIGNER" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JARSIGNER" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -1082,63 +1082,6 @@ name(s) cannot be set in this file.
 .TP
 \f[V]-version\f[R]
 Prints the program version.
-.SH DEPRECATED OPTIONS
-.PP
-The following \f[V]jarsigner\f[R] options are deprecated as of JDK 9 and
-might be removed in a future JDK release.
-.TP
-\f[V]-altsigner\f[R] \f[I]class\f[R]
-This option specifies an alternative signing mechanism.
-The fully qualified class name identifies a class file that extends the
-\f[V]com.sun.jarsigner.ContentSigner\f[R] abstract class.
-The path to this class file is defined by the \f[V]-altsignerpath\f[R]
-option.
-If the \f[V]-altsigner\f[R] option is used, then the \f[V]jarsigner\f[R]
-command uses the signing mechanism provided by the specified class.
-Otherwise, the \f[V]jarsigner\f[R] command uses its default signing
-mechanism.
-.RS
-.PP
-For example, to use the signing mechanism provided by a class named
-\f[V]com.sun.sun.jarsigner.AuthSigner\f[R], use the \f[V]jarsigner\f[R]
-option \f[V]-altsigner com.sun.jarsigner.AuthSigner\f[R].
-.RE
-.TP
-\f[V]-altsignerpath\f[R] \f[I]classpathlist\f[R]
-Specifies the path to the class file and any JAR file it depends on.
-The class file name is specified with the \f[V]-altsigner\f[R] option.
-If the class file is in a JAR file, then this option specifies the path
-to that JAR file.
-.RS
-.PP
-An absolute path or a path relative to the current directory can be
-specified.
-If \f[I]classpathlist\f[R] contains multiple paths or JAR files, then
-they should be separated with a:
-.IP \[bu] 2
-Colon (\f[V]:\f[R]) on Linux and macOS
-.IP \[bu] 2
-Semicolon (\f[V];\f[R]) on Windows
-.PP
-This option isn\[aq]t necessary when the class is already in the search
-path.
-.PP
-The following example shows how to specify the path to a JAR file that
-contains the class file.
-The JAR file name is included.
-.RS
-.PP
-\f[V]-altsignerpath /home/user/lib/authsigner.jar\f[R]
-.RE
-.PP
-The following example shows how to specify the path to the JAR file that
-contains the class file.
-The JAR file name is omitted.
-.RS
-.PP
-\f[V]-altsignerpath /home/user/classes/com/sun/tools/jarsigner/\f[R]
-.RE
-.RE
 .SH ERRORS AND WARNINGS
 .PP
 During the signing or verifying process, the \f[V]jarsigner\f[R] command

--- a/src/jdk.javadoc/share/man/javadoc.1
+++ b/src/jdk.javadoc/share/man/javadoc.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JCMD" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JCMD" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -453,6 +453,8 @@ If no filename is given, a filename is generated from the PID and the
 current date.
 The filename may also be a directory in which case, the filename is
 generated from the PID and the current date in the specified directory.
+If %p and/or %t is specified in the filename, it expands to the
+JVM\[aq]s PID and the current timestamp, respectively.
 (STRING, no default value)
 .IP \[bu] 2
 \f[V]maxage\f[R]: (Optional) Length of time for dumping the flight
@@ -521,6 +523,8 @@ current date and is placed in the directory where the process was
 started.
 The filename may also be a directory in which case, the filename is
 generated from the PID and the current date in the specified directory.
+If %p and/or %t is specified in the filename, it expands to the
+JVM\[aq]s PID and the current timestamp, respectively.
 (STRING, no default value)
 .IP \[bu] 2
 \f[V]maxage\f[R]: (Optional) Maximum time to keep the recorded data on
@@ -612,6 +616,8 @@ If no parameters are entered, then no recording is stopped.
 .IP \[bu] 2
 \f[V]filename\f[R]: (Optional) Name of the file to which the recording
 is written when the recording is stopped.
+If %p and/or %t is specified in the filename, it expands to the
+JVM\[aq]s PID and the current timestamp, respectively.
 If no path is provided, the data from the recording is discarded.
 (STRING, no default value)
 .IP \[bu] 2

--- a/src/jdk.jcmd/share/man/jinfo.1
+++ b/src/jdk.jcmd/share/man/jinfo.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JINFO" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JINFO" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jmap.1
+++ b/src/jdk.jcmd/share/man/jmap.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JMAP" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JMAP" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jps.1
+++ b/src/jdk.jcmd/share/man/jps.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JPS" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JPS" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jstack.1
+++ b/src/jdk.jcmd/share/man/jstack.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSTACK" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JSTACK" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jstat.1
+++ b/src/jdk.jcmd/share/man/jstat.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSTAT" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JSTAT" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jconsole/share/man/jconsole.1
+++ b/src/jdk.jconsole/share/man/jconsole.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JCONSOLE" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JCONSOLE" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jdeps/share/man/javap.1
+++ b/src/jdk.jdeps/share/man/javap.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAVAP" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JAVAP" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jdeps/share/man/jdeprscan.1
+++ b/src/jdk.jdeps/share/man/jdeprscan.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JDEPRSCAN" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JDEPRSCAN" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jdeps/share/man/jdeps.1
+++ b/src/jdk.jdeps/share/man/jdeps.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JDEPS" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JDEPS" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -246,6 +246,7 @@ the pattern to the dependencies.
 .TP
 \f[V]-P\f[R] or \f[V]-profile\f[R]
 Shows the profile containing a package.
+This option is deprecated and may be removed in a future release.
 .TP
 \f[V]-R\f[R] or \f[V]--recursive\f[R]
 Recursively traverses all run-time dependences.

--- a/src/jdk.jdi/share/man/jdb.1
+++ b/src/jdk.jdi/share/man/jdb.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JDB" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JDB" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jfr/share/man/jfr.1
+++ b/src/jdk.jfr/share/man/jfr.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JFR" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JFR" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -221,7 +221,7 @@ Use \f[V]jfr --help view\f[R] to see a list of available views.
 <\f[I]file\f[R]>
 Location of the recording file (.jfr)
 .PP
-The parameter can be an event type name.
+The <\f[I]view\f[R]> parameter can be an event type name.
 Use the \f[V]jfr view types <file>\f[R] to see a list.
 To display all views, use \f[V]jfr view all-views <file>\f[R].
 To display all events, use \f[V]jfr view all-events <file>\f[R].
@@ -258,8 +258,9 @@ To see available options, use \f[V]jfr help configure\f[R]
 .TP
 \f[I]event-setting=value\f[R]
 The event setting value to modify.
-Use the form: <\f[I]event-name>#=<value\f[R]> To add a new event
-setting, prefix the event name with \[aq]+\[aq].
+Use the form:
+<\f[I]event-name\f[R]>#<\f[I]setting-name\f[R]>=<\f[I]value\f[R]> To add
+a new event setting, prefix the event name with \[aq]+\[aq].
 .PP
 The whitespace delimiter can be omitted for timespan values, i.e.
 20ms.
@@ -316,7 +317,7 @@ The syntax is:
 [--exclude-events <\f[I]filter\f[R]>] [--include-categories
 <\f[I]filter\f[R]>] [--exclude-categories <\f[I]filter\f[R]>]
 [--include-threads <\f[I]filter\f[R]>] [--exclude-threads
-<\f[I]filter\f[R]>] <\f[I]input-file\f[R]> []
+<\f[I]filter\f[R]>] <\f[I]input-file\f[R]> [<\f[I]output-file\f[R]>]
 .TP
 \f[V]--include-events\f[R] <\f[I]filter\f[R]>
 Select events matching an event name.
@@ -335,8 +336,9 @@ Select events matching a thread name.
 .TP
 \f[V]--exclude-threads\f[R] <\f[I]filter\f[R]>
 Exclude events matching a thread name.
-.PP
-<\f[I]input-file\f[R]> :The input file to read events from.
+.TP
+<\f[I]input-file\f[R]>
+The input file to read events from.
 .TP
 <\f[I]output-file\f[R]>
 The output file to write filter events to.
@@ -346,7 +348,7 @@ input file, but with \[dq]-scrubbed\[dq] appended to the filename.
 The filter is a comma-separated list of names, simple and/or qualified,
 and/or quoted glob patterns.
 If multiple filters are used, they are applied in the specified order.
-.SS jfr \f[V]assemble\f[R] subcommand
+.SS \f[V]jfr assemble\f[R] subcommand
 .PP
 Use jfr \f[V]assemble\f[R] to assemble chunk files into a recording
 file.

--- a/src/jdk.jlink/share/man/jlink.1
+++ b/src/jdk.jlink/share/man/jlink.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JLINK" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JLINK" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jlink/share/man/jmod.1
+++ b/src/jdk.jlink/share/man/jmod.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JMOD" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JMOD" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jpackage/share/man/jpackage.1
+++ b/src/jdk.jpackage/share/man/jpackage.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JPACKAGE" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JPACKAGE" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jshell/share/man/jshell.1
+++ b/src/jdk.jshell/share/man/jshell.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSHELL" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JSHELL" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -67,6 +67,11 @@ Imports all Java SE packages.
 \f[V]PRINTING\f[R]
 Defines \f[V]print\f[R], \f[V]println\f[R], and \f[V]printf\f[R] as
 \f[V]jshell\f[R] methods for use within the tool.
+.TP
+\f[V]TOOLING\f[R]
+Defines \f[V]javac\f[R], \f[V]jar\f[R], and other methods for running
+JDK tools via their command-line interface within the \f[V]jshell\f[R]
+tool.
 .PP
 For more than one script, use a space to separate the names.
 Scripts are run in the order in which they\[aq]re entered on the command
@@ -231,6 +236,11 @@ Imports all Java SE packages.
 \f[V]PRINTING\f[R]
 Defines \f[V]print\f[R], \f[V]println\f[R], and \f[V]printf\f[R] as
 \f[V]jshell\f[R] methods for use within the tool.
+.TP
+\f[V]TOOLING\f[R]
+Defines \f[V]javac\f[R], \f[V]jar\f[R], and other methods for running
+JDK tools via their command-line interface within the \f[V]jshell\f[R]
+tool.
 .PP
 For more than one script, provide a separate instance of this option for
 each script.
@@ -451,6 +461,11 @@ Imports all Java SE packages.
 \f[V]PRINTING\f[R]
 Defines \f[V]print\f[R], \f[V]println\f[R], and \f[V]printf\f[R] as
 \f[V]jshell\f[R] methods for use within the tool.
+.TP
+\f[V]TOOLING\f[R]
+Defines \f[V]javac\f[R], \f[V]jar\f[R], and other methods for running
+JDK tools via their command-line interface within the \f[V]jshell\f[R]
+tool.
 .RE
 .TP
 \f[V]/reload\f[R] [\f[I]options\f[R]]
@@ -765,6 +780,11 @@ Imports all Java SE packages.
 \f[V]PRINTING\f[R]
 Defines \f[V]print\f[R], \f[V]println\f[R], and \f[V]printf\f[R] as
 \f[V]jshell\f[R] methods for use within the tool.
+.TP
+\f[V]TOOLING\f[R]
+Defines \f[V]javac\f[R], \f[V]jar\f[R], and other methods for running
+JDK tools via their command-line interface within the \f[V]jshell\f[R]
+tool.
 .PP
 The following options are valid:
 .TP

--- a/src/jdk.jstatd/share/man/jstatd.1
+++ b/src/jdk.jstatd/share/man/jstatd.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSTATD" "1" "2023" "JDK 21-ea" "JDK Commands"
+.TH "JSTATD" "1" "2023" "JDK 21" "JDK Commands"
 .hy
 .SH NAME
 .PP


### PR DESCRIPTION
Main changes are to use 21 instead of 21-ea. In addition the following files contain additional updates from the closed sources:

- src/java.base/share/man/java.1

 [JDK-8273131](https://bugs.openjdk.org/browse/JDK-8273131): Update the java manpage markdown source for JFR filename expansion
 [JDK-8221633](https://bugs.openjdk.org/browse/JDK-8221633): StartFlightRecording: consider moving mention of multiple comma-separated parameters to the front

There are also some formatting differences related to:

 [JDK-8309670](https://bugs.openjdk.org/browse/JDK-8309670): java -help output for --module-path / -p is incomplete

Likely a different version of pandoc was used.

- src/java.base/share/man/keytool.1

 [JDK-8290626](https://bugs.openjdk.org/browse/JDK-8290626): keytool manpage contains a special character

- src/jdk.compiler/share/man/javac.1

 [JDK-8308456](https://bugs.openjdk.org/browse/JDK-8308456): Update javac tool page for -proc:full

also some formatting differences.

- src/jdk.jartool/share/man/jarsigner.1

 [JDK-8303928](https://bugs.openjdk.org/browse/JDK-8303928): Update jarsigner man page after [JDK-8303410](https://bugs.openjdk.org/browse/JDK-8303410)

- src/jdk.jcmd/share/man/jcmd.1

 [JDK-8273131](https://bugs.openjdk.org/browse/JDK-8273131): Update the java manpage markdown source for JFR filename expansion

- src/jdk.jdeps/share/man/jdeps.1

 [JDK-8301207](https://bugs.openjdk.org/browse/JDK-8301207): (jdeps) Deprecate jdeps -profile option

- src/jdk.jfr/share/man/jfr.1

Formatting changes.

- src/jdk.jshell/share/man/jshell.1

 [JDK-8308988](https://bugs.openjdk.org/browse/JDK-8308988): Update JShell manpage to include TOOLING description

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300937](https://bugs.openjdk.org/browse/JDK-8300937): Update nroff pages in JDK 21 before RC (**Task** - P3)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/151/head:pull/151` \
`$ git checkout pull/151`

Update a local copy of the PR: \
`$ git checkout pull/151` \
`$ git pull https://git.openjdk.org/jdk21.git pull/151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 151`

View PR using the GUI difftool: \
`$ git pr show -t 151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/151.diff">https://git.openjdk.org/jdk21/pull/151.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/151#issuecomment-1657924043)