### PR TITLE
8303549: [AIX] TestNativeStack.java is failing with exit value 1

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/getCreatedJavaVMs/exeGetCreatedJavaVMs.c
+++ b/test/hotspot/jtreg/runtime/jni/getCreatedJavaVMs/exeGetCreatedJavaVMs.c
@@ -89,14 +89,19 @@ void *thread_runner(void *threadid) {
 
 int main (int argc, char* argv[]) {
   pthread_t threads[NUM_THREADS];
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  size_t stack_size = 0x100000;
+  pthread_attr_setstacksize(&attr, stack_size);
   for (int i = 0; i < NUM_THREADS; i++ ) {
     printf("[*] Creating thread %d\n", i);
-    int status = pthread_create(&threads[i], NULL, thread_runner, (void *)(intptr_t)i);
+    int status = pthread_create(&threads[i], &attr, thread_runner, (void *)(intptr_t)i);
     if (status != 0) {
       printf("[*] Error creating thread %d - %d\n", i, status);
       exit(-1);
     }
   }
+  pthread_attr_destroy(&attr);
   for (int i = 0; i < NUM_THREADS; i++ ) {
     pthread_join(threads[i], NULL);
   }

--- a/test/hotspot/jtreg/runtime/jni/nativeStack/libnativeStack.c
+++ b/test/hotspot/jtreg/runtime/jni/nativeStack/libnativeStack.c
@@ -109,10 +109,17 @@ Java_TestNativeStack_triggerJNIStackTrace
 
   warning = warn;
 
-  if ((res = pthread_create(&thread, NULL, thread_start, NULL)) != 0) {
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  size_t stack_size = 0x100000;
+  pthread_attr_setstacksize(&attr, stack_size);
+
+  if ((res = pthread_create(&thread, &attr, thread_start, NULL)) != 0) {
     fprintf(stderr, "TEST ERROR: pthread_create failed: %s (%d)\n", strerror(res), res);
     exit(1);
   }
+
+  pthread_attr_destroy(&attr);
 
   if ((res = pthread_join(thread, NULL)) != 0) {
     fprintf(stderr, "TEST ERROR: pthread_join failed: %s (%d)\n", strerror(res), res);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8303549](https://bugs.openjdk.org/browse/JDK-8303549), commit [5ff42d14](https://github.com/openjdk/jdk/commit/5ff42d14294199eb3bf10b66530f9249fb68810d) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Varada M on 26 Jun 2023 and was reviewed by David Holmes and Gerard Ziemski.

As it is a test fix only, it should qualify for RDP2.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303549](https://bugs.openjdk.org/browse/JDK-8303549): [AIX] TestNativeStack.java is failing with exit value 1 (**Bug** - P3)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/155/head:pull/155` \
`$ git checkout pull/155`

Update a local copy of the PR: \
`$ git checkout pull/155` \
`$ git pull https://git.openjdk.org/jdk21.git pull/155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 155`

View PR using the GUI difftool: \
`$ git pr show -t 155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/155.diff">https://git.openjdk.org/jdk21/pull/155.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/155#issuecomment-1660625938)