### PR TITLE
8311822: AIX : test/jdk/java/foreign/TestLayouts.java fails because of different output - expected [[i4](struct)] but found [[I4](struct)]

### DIFF
--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -260,10 +260,13 @@ public class TestLayouts {
 
     @Test
     public void testStructToString() {
-        StructLayout padding = MemoryLayout.structLayout(JAVA_INT).withName("struct");
-        assertEquals(padding.toString(), "[i4](struct)");
-        var toStringUnaligned = padding.withByteAlignment(8).toString();
-        assertEquals(toStringUnaligned, "8%[i4](struct)");
+        for (ByteOrder order : List.of(ByteOrder.LITTLE_ENDIAN, ByteOrder.BIG_ENDIAN)) {
+            String intRepresentation = (order == ByteOrder.LITTLE_ENDIAN ? "i" : "I");
+            StructLayout padding = MemoryLayout.structLayout(JAVA_INT.withOrder(order)).withName("struct");
+            assertEquals(padding.toString(), "[" + intRepresentation + "4](struct)");
+            var toStringUnaligned = padding.withByteAlignment(8).toString();
+            assertEquals(toStringUnaligned, "8%[" + intRepresentation + "4](struct)");
+        }
     }
 
     @Test(dataProvider = "layoutKinds")


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8311822](https://bugs.openjdk.org/browse/JDK-8311822), commit [d1cc2782](https://github.com/openjdk/jdk/commit/d1cc2782606e8a3cfead9055aa845e48e851edd4) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Per Minborg on 24 Jul 2023 and was reviewed by Jorn Vernee.


Test fix, so qualifying for jdk21 under RDP2 rules.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311822](https://bugs.openjdk.org/browse/JDK-8311822): AIX : test/jdk/java/foreign/TestLayouts.java fails because of different output - expected [[i4](struct)] but found [[I4](struct)] (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/157/head:pull/157` \
`$ git checkout pull/157`

Update a local copy of the PR: \
`$ git checkout pull/157` \
`$ git pull https://git.openjdk.org/jdk21.git pull/157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 157`

View PR using the GUI difftool: \
`$ git pr show -t 157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/157.diff">https://git.openjdk.org/jdk21/pull/157.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/157#issuecomment-1661160447)