### PR TITLE
8313404: Fix section label in test/jdk/ProblemList.txt

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -757,6 +757,12 @@ jdk/jfr/api/consumer/recordingstream/TestOnEvent.java           8255404 linux-x6
 # jdk_jpackage
 
 ############################################################################
+
+# jdk_foreign
+
+java/foreign/TestByteBuffer.java 8309475 aix-ppc64
+
+############################################################################
 # Client manual tests
 
 javax/swing/JFileChooser/6698013/bug6698013.java 8024419 macosx-all
@@ -787,8 +793,3 @@ java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter.java 8254841 macos
 java/awt/Focus/AppletInitialFocusTest/AppletInitialFocusTest1.java 8256289 windows-x64
 java/awt/FullScreen/TranslucentWindow/TranslucentWindow.java 8258103 linux-all
 java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java 8016266 linux-x64
-
-############################################################################
-# java/foreign
-
-java/foreign/TestByteBuffer.java 8309475 aix-ppc64


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8313404](https://bugs.openjdk.org/browse/JDK-8313404), commit [94b50b71](https://github.com/openjdk/jdk/commit/94b50b714a3d7696908e13b44eceeec60b82fcc6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christoph Langer on 1 Aug 2023 and was reviewed by Matthias Baesken and Alan Bateman.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313404](https://bugs.openjdk.org/browse/JDK-8313404): Fix section label in test/jdk/ProblemList.txt (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/158/head:pull/158` \
`$ git checkout pull/158`

Update a local copy of the PR: \
`$ git checkout pull/158` \
`$ git pull https://git.openjdk.org/jdk21.git pull/158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 158`

View PR using the GUI difftool: \
`$ git pr show -t 158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/158.diff">https://git.openjdk.org/jdk21/pull/158.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/158#issuecomment-1661631900)