### PR TITLE
8312574: jdk/jdk/jfr/jvm/TestChunkIntegrity.java  fails with timeout

### DIFF
--- a/test/jdk/jdk/jfr/jvm/TestChunkIntegrity.java
+++ b/test/jdk/jdk/jfr/jvm/TestChunkIntegrity.java
@@ -59,7 +59,7 @@ import jdk.test.lib.jfr.TestClassLoader;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
- * @run main/othervm jdk.jfr.jvm.TestChunkIntegrity
+ * @run main/othervm/timeout=300 jdk.jfr.jvm.TestChunkIntegrity
  */
 public class TestChunkIntegrity {
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312574](https://bugs.openjdk.org/browse/JDK-8312574): jdk/jdk/jfr/jvm/TestChunkIntegrity.java  fails with timeout (**Bug** - P3)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/162/head:pull/162` \
`$ git checkout pull/162`

Update a local copy of the PR: \
`$ git checkout pull/162` \
`$ git pull https://git.openjdk.org/jdk21.git pull/162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 162`

View PR using the GUI difftool: \
`$ git pr show -t 162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/162.diff">https://git.openjdk.org/jdk21/pull/162.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/162#issuecomment-1663431837)