### PR TITLE
8313593: Generational ZGC: NMT assert when the heap fails to expand

### DIFF
--- a/src/hotspot/share/gc/z/zPhysicalMemory.cpp
+++ b/src/hotspot/share/gc/z/zPhysicalMemory.cpp
@@ -309,7 +309,9 @@ bool ZPhysicalMemoryManager::commit(ZPhysicalMemory& pmem) {
     const size_t committed = _backing.commit(segment.start(), segment.size());
 
     // Register with NMT
-    ZNMT::commit(segment.start(), committed);
+    if (committed > 0) {
+      ZNMT::commit(segment.start(), committed);
+    }
 
     // Register committed segment
     if (!pmem.commit_segment(i, committed)) {
@@ -335,7 +337,9 @@ bool ZPhysicalMemoryManager::uncommit(ZPhysicalMemory& pmem) {
     const size_t uncommitted = _backing.uncommit(segment.start(), segment.size());
 
     // Unregister with NMT
-    ZNMT::uncommit(segment.start(), uncommitted);
+    if (uncommitted > 0) {
+      ZNMT::uncommit(segment.start(), uncommitted);
+    }
 
     // Deregister uncommitted segment
     if (!pmem.uncommit_segment(i, uncommitted)) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [19e2c8c3](https://github.com/openjdk/jdk/commit/19e2c8c321823c056091e6e9f6c3d0db7ba9ec2b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Stefan Karlsson on 2 Aug 2023 and was reviewed by Thomas Stuefe, Thomas Schatzl and Erik Österlund.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313593](https://bugs.openjdk.org/browse/JDK-8313593): Generational ZGC: NMT assert when the heap fails to expand (**Bug** - P2)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/163/head:pull/163` \
`$ git checkout pull/163`

Update a local copy of the PR: \
`$ git checkout pull/163` \
`$ git pull https://git.openjdk.org/jdk21.git pull/163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 163`

View PR using the GUI difftool: \
`$ git pr show -t 163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/163.diff">https://git.openjdk.org/jdk21/pull/163.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/163#issuecomment-1665090599)