### PR TITLE
8313345: SuperWord fails due to CMove without matching Bool pack

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2196,6 +2196,18 @@ bool SuperWord::profitable(Node_List* p) {
       }
     }
   }
+  if (p0->is_CMove()) {
+    // Verify that CMove has a matching Bool pack
+    BoolNode* bol = p0->in(1)->as_Bool();
+    if (bol == nullptr || my_pack(bol) == nullptr) {
+      return false;
+    }
+    // Verify that Bool has a matching Cmp pack
+    CmpNode* cmp = bol->in(1)->as_Cmp();
+    if (cmp == nullptr || my_pack(cmp) == nullptr) {
+      return false;
+    }
+  }
   return true;
 }
 

--- a/test/hotspot/jtreg/compiler/vectorization/TestCMoveWithoutBoolPack.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestCMoveWithoutBoolPack.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8313345
+ * @summary Test SuperWord with a CMove that does not have a matching bool pack.
+ * @requires vm.compiler2.enabled
+ * @run main/othervm -XX:-TieredCompilation -XX:CompileCommand=compileonly,*TestCMoveWithoutBoolPack*::fill -Xbatch
+ *                   compiler.vectorization.TestCMoveWithoutBoolPack
+ * @run main/othervm -XX:-TieredCompilation -XX:CompileCommand=compileonly,*TestCMoveWithoutBoolPack*::fill -Xbatch
+ *                   -XX:+UseCMoveUnconditionally
+ *                   compiler.vectorization.TestCMoveWithoutBoolPack
+ */
+
+package compiler.vectorization;
+
+public class TestCMoveWithoutBoolPack {
+
+    public static void main(String[] args) {
+        A a = new A();
+        B b = new B();
+        double[] c = new double[1000];
+        for (int i = 0; i < 1000; i++) {
+            a.fill(c);
+            b.fill(c);
+        }
+    }
+
+    public static class A {
+        void fill(double[] array) {
+            for (int i = 0; i < array.length; ++i) {
+                array[i] = this.transform(array[i]);
+            }
+        }
+
+        public double transform(double value) {
+            return value * value;
+        }
+    }
+
+    public static class B extends A {
+        public double transform(double value) {
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8313345](https://bugs.openjdk.java.net/browse/JDK-8313345). Applies cleanly.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313345](https://bugs.openjdk.org/browse/JDK-8313345): SuperWord fails due to CMove without matching Bool pack (**Bug** - P2)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/168/head:pull/168` \
`$ git checkout pull/168`

Update a local copy of the PR: \
`$ git checkout pull/168` \
`$ git pull https://git.openjdk.org/jdk21.git pull/168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 168`

View PR using the GUI difftool: \
`$ git pr show -t 168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/168.diff">https://git.openjdk.org/jdk21/pull/168.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/168#issuecomment-1670703874)