### PR TITLE
8315206: RISC-V: hwprobe query is_set return wrong value

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -100,7 +100,7 @@ static bool is_valid(int64_t key) {
 
 static bool is_set(int64_t key, uint64_t value_mask) {
   if (is_valid(key)) {
-    return query[key].value & value_mask != 0;
+    return (query[key].value & value_mask) != 0;
   }
   return false;
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [876a725a](https://github.com/openjdk/jdk/commit/876a725af95d65d59390c86bfec64c33cccbf53b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Robbin Ehn on 30 Aug 2023 and was reviewed by Ludovic Henry and Fei Yang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315206](https://bugs.openjdk.org/browse/JDK-8315206): RISC-V: hwprobe query is_set return wrong value (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk21.git pull/175/head:pull/175` \
`$ git checkout pull/175`

Update a local copy of the PR: \
`$ git checkout pull/175` \
`$ git pull https://git.openjdk.org/jdk21.git pull/175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 175`

View PR using the GUI difftool: \
`$ git pr show -t 175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk21/pull/175.diff">https://git.openjdk.org/jdk21/pull/175.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk21/pull/175#issuecomment-1700560192)